### PR TITLE
feat: automatic prediction refresh and last run timestamp

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -1,5 +1,8 @@
 import json
+import logging
 import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 from fastapi import BackgroundTasks, FastAPI, File, HTTPException, UploadFile, Depends
 from fastapi.middleware.cors import CORSMiddleware
@@ -40,19 +43,44 @@ async def health_check():
 # Background task
 # =============================================================================
 
-def run_prophet_background(df: pd.DataFrame, company_id: int, data_source_id: int):
-    """Runs Prophet pipeline in background and updates DataSource status."""
+def run_prophet_background(company_id: int, data_source_id: int):
+    """
+    Runs Prophet pipeline in background and updates DataSource status.
+    Always trains on the full historical data stored in sales_transaction,
+    so successive uploads accumulate — not overwrite — the training set.
+    """
     db = SessionLocal()
     try:
-        # Update status to processing
         data_source = db.query(DataSource).filter(DataSource.id == data_source_id).first()
         data_source.status = "processing"
         db.commit()
 
-        # Run Prophet pipeline
-        run_pipeline(df, company_id=company_id)
+        # Load full historical data from DB (includes all previous uploads via upsert)
+        rows = (
+            db.query(SalesTransaction)
+            .filter(SalesTransaction.company_id == company_id)
+            .all()
+        )
+        if not rows:
+            data_source.status = "failed"
+            db.commit()
+            logger.error("Prophet pipeline: no sales data found for company_id=%d", company_id)
+            return
 
-        # Update status to ready
+        full_df = pd.DataFrame([{
+            "item_id": r.item_id,
+            "store_id": r.store_id,
+            "cat_id": r.cat_id,
+            "dept_id": r.dept_id,
+            "date": pd.Timestamp(r.date),
+            "units_sold": r.units_sold,
+            "sell_price": float(r.sell_price) if r.sell_price is not None else None,
+            "holiday_promotion": r.holiday_promotion,
+            "event_name_1": r.event_name_1,
+        } for r in rows])
+
+        run_pipeline(full_df, company_id=company_id)
+
         data_source.status = "ready"
         db.commit()
 
@@ -60,7 +88,7 @@ def run_prophet_background(df: pd.DataFrame, company_id: int, data_source_id: in
         data_source = db.query(DataSource).filter(DataSource.id == data_source_id).first()
         data_source.status = "failed"
         db.commit()
-        print(f"Prophet pipeline failed: {e}")
+        logger.exception("Prophet pipeline failed for company_id=%d", company_id)
     finally:
         db.close()
 
@@ -147,10 +175,9 @@ async def upload_sales(
         db.commit()
         transactions = records
 
-        # Step 6: Trigger Prophet pipeline in background
+        # Step 5: Trigger Prophet pipeline in background
         background_tasks.add_task(
             run_prophet_background,
-            df=dataframe,
             company_id=company_id,
             data_source_id=data_source.id,
         )
@@ -277,6 +304,7 @@ async def upload_inventory(
     description="Returns the status of the latest demand forecast pipeline run. Frontend polls this endpoint to know when predictions are ready.",
 )
 async def get_predictions_status(db: Session = Depends(get_db)):
+    """Return pipeline status and the timestamp of the last completed forecast run."""
     try:
         data_source = (
             db.query(DataSource)
@@ -285,7 +313,7 @@ async def get_predictions_status(db: Session = Depends(get_db)):
         )
 
         if not data_source:
-            return {"status": "no_data", "message": "No files uploaded yet."}
+            return {"status": "no_data", "message": "No files uploaded yet.", "last_run_at": None}
 
         messages = {
             "uploaded":   "File received. Forecast pipeline starting...",
@@ -294,11 +322,20 @@ async def get_predictions_status(db: Session = Depends(get_db)):
             "failed":     "Forecast generation failed. Please try uploading again.",
         }
 
+        last_prediction = (
+            db.query(Prediction.created_at)
+            .filter(Prediction.company_id == data_source.company_id)
+            .order_by(Prediction.created_at.desc())
+            .first()
+        )
+        last_run_at = last_prediction.created_at.isoformat() if last_prediction else None
+
         return {
             "status": data_source.status,
             "message": messages.get(data_source.status, "Unknown status."),
             "filename": data_source.filename,
             "upload_date": data_source.upload_date.isoformat(),
+            "last_run_at": last_run_at,
         }
 
     except Exception as e:

--- a/backend/demand_forecast/prophet_demand_forecast.py
+++ b/backend/demand_forecast/prophet_demand_forecast.py
@@ -138,6 +138,7 @@ def prepare_prophet_df(data, sku):
           .rename(columns={'date': 'ds', 'units_sold': 'y'})
           .sort_values('ds')
           .reset_index(drop=True))
+    df['ds'] = pd.to_datetime(df['ds'])
     return df
 
 def train_prophet(df_train, holidays_df, params):
@@ -170,7 +171,36 @@ def evaluate(forecast, df_test):
 # =============================================================================
 
 def hyperparameter_tuning(df_train, holidays_df):
+    """
+    Tune Prophet hyperparameters via cross-validation.
+    CV windows scale with available data; falls back to sensible defaults
+    when the dataset is too short for meaningful cross-validation.
+    """
     print("Running hyperparameter tuning on pilot SKU...")
+
+    DEFAULT_PARAMS = {
+        'changepoint_prior_scale': 0.05,
+        'seasonality_prior_scale': 1.0,
+        'seasonality_mode': 'additive',
+    }
+
+    n_days = (df_train['ds'].max() - df_train['ds'].min()).days if len(df_train) > 1 else 0
+
+    # Horizon is fixed at 90 days — matches our forecast period.
+    # Initial scales with available data but is capped at the original 1460 days.
+    # A valid CV fold requires: initial + period + horizon ≤ n_days.
+    # With period=horizon=90 that means initial ≤ n_days - 180.
+    # We also enforce initial ≥ 180 (2× horizon) for a meaningful training window.
+    HORIZON_DAYS = 90
+    initial_days = min(1460, n_days - 2 * HORIZON_DAYS)  # leaves room for one full fold
+
+    if initial_days < 180:
+        print(f"Skipping CV tuning ({n_days} days of pilot data) — using default parameters.\n")
+        return DEFAULT_PARAMS
+
+    initial = f'{initial_days} days'
+    horizon = f'{HORIZON_DAYS} days'
+    period  = '90 days'
 
     param_grid = {
         'changepoint_prior_scale': [0.01, 0.05, 0.1, 0.5],
@@ -192,8 +222,8 @@ def hyperparameter_tuning(df_train, holidays_df):
         m.add_regressor('sell_price')
         m.fit(df_train)
 
-        df_cv = cross_validation(m, initial='1460 days',
-                                 period='90 days', horizon='90 days',
+        df_cv = cross_validation(m, initial=initial,
+                                 period=period, horizon=horizon,
                                  parallel='processes')
         df_m = performance_metrics(df_cv)
         results.append({**params, 'mae': df_m['mae'].mean()})
@@ -369,7 +399,12 @@ def plot_metrics_summary(df_metrics):
 # =============================================================================
 
 def save_predictions_to_db(forecasts, company_id=1):
-    
+    """
+    Persist forecast results to the prediction table.
+    Deletes existing predictions for the company and inserts the new batch in one
+    bulk operation. All rows in a single batch share the same created_at timestamp,
+    which is used by GET /api/predictions/status as the last_run_at signal.
+    """
     db: Session = SessionLocal()
 
     try:
@@ -425,14 +460,15 @@ def run_pipeline(df: pd.DataFrame, company_id: int = 1):
     Called from POST /upload-sales as a background task.
     Trains on ALL historical data and forecasts the next 90 days.
     """
-    CUTOFF_DAYS   = 90   # used only for pilot hyperparameter tuning
     FORECAST_DAYS = 90
 
     holidays_df = build_holidays(df)
 
-    # Use a tuning cutoff only for hyperparameter search (pilot SKU)
-    # The actual training uses all available data
-    tuning_cutoff = df['date'].max() - pd.Timedelta(days=CUTOFF_DAYS)
+    # Tuning cutoff: reserve 20% of the dataset for pilot CV, capped at 90 days.
+    # This keeps df_pilot_train non-empty even for short test files.
+    data_span_days = (df['date'].max() - df['date'].min()).days
+    tuning_cutoff_days = max(7, min(90, int(data_span_days * 0.2)))
+    tuning_cutoff = df['date'].max() - pd.Timedelta(days=tuning_cutoff_days)
     full_cutoff   = df['date'].max()  # train on everything
 
     # Pilot SKU tuning (uses tuning_cutoff to have test data for CV)

--- a/frontend/src/app/predictions/page.tsx
+++ b/frontend/src/app/predictions/page.tsx
@@ -231,9 +231,18 @@ export default function PredictionsPage() {
   const [selectedSku, setSelectedSku] = useState<string>("")
   const [granularity, setGranularity] = useState<Granularity>("daily")
   const [errorMsg, setErrorMsg] = useState("")
+  const [refreshKey, setRefreshKey] = useState(0)
 
-  // Load pipeline status + predictions on mount
+  // Re-load when the pipeline completes a new run
   useEffect(() => {
+    const handler = () => setRefreshKey((k) => k + 1)
+    window.addEventListener("pipeline:dataready", handler)
+    return () => window.removeEventListener("pipeline:dataready", handler)
+  }, [])
+
+  // Load pipeline status + predictions on mount and after each pipeline completion
+  useEffect(() => {
+    setPageState("loading")
     getPredictionsStatus()
       .then((status) => {
         if (status.status === "no_data") { setPageState("no_data"); return }
@@ -253,7 +262,7 @@ export default function PredictionsPage() {
         setErrorMsg(axios.isAxiosError(err) ? (err.response?.data?.detail ?? err.message) : "Error desconocido")
         setPageState("error")
       })
-  }, [])
+  }, [refreshKey])
 
   // Load all sales (no date filter — data is historical, not recent)
   useEffect(() => {
@@ -308,7 +317,7 @@ export default function PredictionsPage() {
   }
 
   return (
-    <DashboardLayout title="Predicciones de Demanda" subtitle="Pronósticos ML con intervalos de confianza por SKU">
+    <DashboardLayout title="Predicciones de Demanda" subtitle="Pronósticos ML con intervalos de confianza por SKU" showLastRunAt>
 
       {/* Loading */}
       {pageState === "loading" && (

--- a/frontend/src/components/alerts-table.tsx
+++ b/frontend/src/components/alerts-table.tsx
@@ -69,8 +69,16 @@ export function AlertsTable() {
   const [alerts, setAlerts] = useState<AlertRow[]>([])
   const [loading, setLoading] = useState(true)
   const [hasTbd, setHasTbd] = useState(false)
+  const [refreshKey, setRefreshKey] = useState(0)
 
   useEffect(() => {
+    const handler = () => setRefreshKey((k) => k + 1)
+    window.addEventListener("pipeline:dataready", handler)
+    return () => window.removeEventListener("pipeline:dataready", handler)
+  }, [])
+
+  useEffect(() => {
+    setLoading(true)
     getInventory()
       .then((res) => {
         setAlerts(buildAlerts(res.items))
@@ -78,7 +86,7 @@ export function AlertsTable() {
       })
       .catch(() => setAlerts([]))
       .finally(() => setLoading(false))
-  }, [])
+  }, [refreshKey])
 
   return (
     <Card className="bg-card">

--- a/frontend/src/components/dashboard-charts.tsx
+++ b/frontend/src/components/dashboard-charts.tsx
@@ -76,8 +76,10 @@ interface TopSkuPoint {
 export function SalesForecastChart() {
   const [data, setData] = useState<TopSkuPoint[]>([])
   const [loading, setLoading] = useState(true)
+  const [refreshKey, setRefreshKey] = useState(0)
 
   useEffect(() => {
+    setLoading(true)
     getPredictions()
       .then((preds) => {
         if (preds.length === 0) { setData([]); return }
@@ -98,6 +100,12 @@ export function SalesForecastChart() {
       })
       .catch(() => setData([]))
       .finally(() => setLoading(false))
+  }, [refreshKey])
+
+  useEffect(() => {
+    const handler = () => setRefreshKey((k) => k + 1)
+    window.addEventListener("pipeline:dataready", handler)
+    return () => window.removeEventListener("pipeline:dataready", handler)
   }, [])
 
   if (loading) return <ChartSkeleton />
@@ -165,8 +173,10 @@ interface InventoryPoint {
 export function InventoryChart() {
   const [data, setData] = useState<InventoryPoint[]>([])
   const [loading, setLoading] = useState(true)
+  const [refreshKey, setRefreshKey] = useState(0)
 
   useEffect(() => {
+    setLoading(true)
     getInventory()
       .then((res) => {
         const sorted = [...res.items]
@@ -181,6 +191,12 @@ export function InventoryChart() {
       })
       .catch(() => setData([]))
       .finally(() => setLoading(false))
+  }, [refreshKey])
+
+  useEffect(() => {
+    const handler = () => setRefreshKey((k) => k + 1)
+    window.addEventListener("pipeline:dataready", handler)
+    return () => window.removeEventListener("pipeline:dataready", handler)
   }, [])
 
   if (loading) return <ChartSkeleton />
@@ -236,8 +252,10 @@ interface CategoryPoint {
 export function CategoryDistributionChart() {
   const [data, setData] = useState<CategoryPoint[]>([])
   const [loading, setLoading] = useState(true)
+  const [refreshKey, setRefreshKey] = useState(0)
 
   useEffect(() => {
+    setLoading(true)
     getSales()
       .then((sales) => {
         const byCategory: Record<string, number> = {}
@@ -254,6 +272,12 @@ export function CategoryDistributionChart() {
       })
       .catch(() => setData([]))
       .finally(() => setLoading(false))
+  }, [refreshKey])
+
+  useEffect(() => {
+    const handler = () => setRefreshKey((k) => k + 1)
+    window.addEventListener("pipeline:dataready", handler)
+    return () => window.removeEventListener("pipeline:dataready", handler)
   }, [])
 
   if (loading) return <ChartSkeleton />

--- a/frontend/src/components/dashboard-layout.tsx
+++ b/frontend/src/components/dashboard-layout.tsx
@@ -12,16 +12,19 @@ interface DashboardLayoutProps {
   children: ReactNode
   title?: string
   subtitle?: string
+  showLastRunAt?: boolean
 }
 
 const POLL_INTERVAL = 10000
 
-export function DashboardLayout({ children, title, subtitle }: DashboardLayoutProps) {
+/** Shared layout wrapper: sidebar, page header, pipeline status polling, and notifications. */
+export function DashboardLayout({ children, title, subtitle, showLastRunAt }: DashboardLayoutProps) {
   const { isAuthenticated, isLoading } = useAuth()
   const router = useRouter()
 
   // Pipeline notification state
   const [pipelineStatus, setPipelineStatus] = useState<PredictionsStatus["status"]>("no_data")
+  const [lastRunAt, setLastRunAt] = useState<string | null>(null)
   const [toastVisible, setToastVisible] = useState(false)
   const [toastDismissed, setToastDismissed] = useState(false)
   const prevStatusRef = useRef<PredictionsStatus["status"]>("no_data")
@@ -39,8 +42,9 @@ export function DashboardLayout({ children, title, subtitle }: DashboardLayoutPr
       const next = data.status
       prevStatusRef.current = next
       setPipelineStatus(next)
+      if (data.last_run_at) setLastRunAt(data.last_run_at)
 
-      // Show toast only on transition TO processing/ready/failed — not on initial load
+      // Show toast on status transitions; also fires on initial load if already processing
       if (prev !== next) {
         if (next === "processing" || next === "uploaded") {
           setToastDismissed(false)
@@ -53,6 +57,7 @@ export function DashboardLayout({ children, title, subtitle }: DashboardLayoutPr
           // Auto-dismiss after 10s
           if (autoDismissRef.current) clearTimeout(autoDismissRef.current)
           autoDismissRef.current = setTimeout(() => setToastVisible(false), 10000)
+          window.dispatchEvent(new CustomEvent("pipeline:dataready"))
           stopPolling()
         }
         if (next === "failed") {
@@ -120,10 +125,24 @@ export function DashboardLayout({ children, title, subtitle }: DashboardLayoutPr
                 <p className="text-sm text-muted-foreground">{subtitle}</p>
               )}
             </div>
-            <NotificationBell
-              hasActiveNotification={(pipelineStatus === "processing" || pipelineStatus === "uploaded" || pipelineStatus === "failed") && toastDismissed}
-              onClick={() => { setToastDismissed(false); setToastVisible(true) }}
-            />
+            <div className="flex items-center gap-3">
+              {showLastRunAt && lastRunAt && (
+                <span className="hidden text-xs text-muted-foreground sm:block">
+                  Actualizado:{" "}
+                  {new Date(lastRunAt).toLocaleString("es-CO", {
+                    day: "numeric",
+                    month: "short",
+                    year: "numeric",
+                    hour: "numeric",
+                    minute: "2-digit",
+                  })}
+                </span>
+              )}
+              <NotificationBell
+                hasActiveNotification={(pipelineStatus === "processing" || pipelineStatus === "uploaded" || pipelineStatus === "failed") && toastDismissed}
+                onClick={() => { setToastDismissed(false); setToastVisible(true) }}
+              />
+            </div>
           </div>
           <div className="px-6 py-6 lg:px-8">{children}</div>
         </main>
@@ -132,6 +151,7 @@ export function DashboardLayout({ children, title, subtitle }: DashboardLayoutPr
       <PipelineToast
         status={pipelineStatus}
         visible={toastVisible}
+        lastRunAt={lastRunAt ?? undefined}
         onDismiss={() => { setToastVisible(false); setToastDismissed(true) }}
       />
     </div>

--- a/frontend/src/components/kpi-cards.tsx
+++ b/frontend/src/components/kpi-cards.tsx
@@ -100,8 +100,21 @@ function formatPct(current: number, prev: number): { label: string; type: "posit
 export function KpiCardsGrid() {
   const [loading, setLoading] = useState(true)
   const [kpis, setKpis] = useState<KpiCardProps[]>([])
+  const [refreshKey, setRefreshKey] = useState(0)
 
   useEffect(() => {
+    const handler = () => setRefreshKey((k) => k + 1)
+    window.addEventListener("pipeline:dataready", handler)
+    // sales_transaction is persisted immediately on upload — no need to wait for Prophet
+    window.addEventListener("pipeline:refetch", handler)
+    return () => {
+      window.removeEventListener("pipeline:dataready", handler)
+      window.removeEventListener("pipeline:refetch", handler)
+    }
+  }, [])
+
+  useEffect(() => {
+    setLoading(true)
     async function load() {
       try {
         // Use the latest available date in the dataset as "now"
@@ -193,7 +206,7 @@ export function KpiCardsGrid() {
     }
 
     load()
-  }, [])
+  }, [refreshKey])
 
   return (
     <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">

--- a/frontend/src/components/pipeline-toast.tsx
+++ b/frontend/src/components/pipeline-toast.tsx
@@ -11,9 +11,11 @@ interface PipelineToastProps {
   status: PredictionsStatus["status"]
   visible: boolean
   onDismiss: () => void
+  lastRunAt?: string
 }
 
-export function PipelineToast({ status, visible, onDismiss }: PipelineToastProps) {
+/** Floating toast that shows Prophet pipeline status transitions and the last-run timestamp. */
+export function PipelineToast({ status, visible, onDismiss, lastRunAt }: PipelineToastProps) {
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => { setMounted(true) }, [])
@@ -51,9 +53,22 @@ export function PipelineToast({ status, visible, onDismiss }: PipelineToastProps
               <p className="text-xs text-muted-foreground mt-0.5">
                 {(status === "processing" || status === "uploaded") && "Esto puede tomar varios minutos."}
                 {status === "ready" && (
-                  <Link href="/predictions" className="text-primary hover:underline">
-                    Ver predicciones →
-                  </Link>
+                  <>
+                    {lastRunAt && (
+                      <span className="block">
+                        {new Date(lastRunAt).toLocaleString("es-CO", {
+                          day: "numeric",
+                          month: "short",
+                          year: "numeric",
+                          hour: "numeric",
+                          minute: "2-digit",
+                        })}
+                      </span>
+                    )}
+                    <Link href="/predictions" className="text-primary hover:underline">
+                      Ver predicciones →
+                    </Link>
+                  </>
                 )}
                 {status === "failed" && "Intenta subir el archivo nuevamente."}
               </p>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -95,6 +95,7 @@ export interface PredictionsStatus {
   message: string
   filename?: string
   upload_date?: string
+  last_run_at?: string
 }
 
 export interface SalesRange {

--- a/frontend/src/next-env.d.ts
+++ b/frontend/src/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## What changed
Backend:                                                                                                                                                             
- GET /api/predictions/status now returns last_run_at (ISO timestamp of the most recent prediction batch)                                                          
- run_prophet_background loads the full historical data from sales_transaction in DB instead of the uploaded dataframe — pipeline always trains on the cumulative    
dataset                                                                                                                                                          
- Fixed datetime coercion bug: SQLAlchemy date objects now coerced with pd.Timestamp to avoid merge errors                                                           
- Fixed adaptive cross-validation: initial_days = min(1460, n_days − 2×HORIZON) keeps the horizon at 90 days and skips tuning on short datasets
                                                                                               
Frontend:                                                                                                                                                            
- Last run timestamp visible in the Predictions page header (right side, next to the notification bell)                                                              
- PipelineToast shows the timestamp alongside "¡Predicciones listas!"                                                                                                
- Dashboard charts, alerts table, and predictions page auto-refresh when the pipeline completes (pipeline:dataready event)                                         
- Sales KPIs (Ventas del Mes) refresh immediately on upload via pipeline:refetch, without waiting for Prophet to finish   

## Related issue
Closes US-12