### PR TITLE
feat(inventory-ux): stockout alerts redesign, global notifications, and inventory guide

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -598,20 +598,29 @@ async def get_inventory(db: Session = Depends(get_db)):
     "/api/inventory/alerts",
     tags=["Inventory"],
     summary="Get stockout risk alerts per SKU",
-    description="Identifies SKUs where projected demand exceeds available inventory within the lead time window.",
+    description=(
+        "Identifies SKUs at risk of stockout. "
+        "Uses demand forecast (Prophet) when available; falls back to historical sales rate otherwise. "
+        "Response includes alert_mode so the frontend can communicate the data source to the user."
+    ),
 )
 async def get_inventory_alerts(db: Session = Depends(get_db)):
     try:
+        from sqlalchemy import func as sqlfunc
+        from datetime import timedelta
+        import math
+
         company = db.query(Company).order_by(Company.id.asc()).first()
         if not company:
-            return {"alerts": []}
+            return {"alerts": [], "alert_mode": "no_data", "message": "No hay datos disponibles."}
 
-        # Get latest inventory snapshot per SKU
-        from sqlalchemy import func
+        # ------------------------------------------------------------------
+        # Latest inventory snapshot per SKU
+        # ------------------------------------------------------------------
         latest_dates = (
             db.query(
                 InventorySnapshot.item_id,
-                func.max(InventorySnapshot.date).label("max_date"),
+                sqlfunc.max(InventorySnapshot.date).label("max_date"),
             )
             .filter(InventorySnapshot.company_id == company.id)
             .group_by(InventorySnapshot.item_id)
@@ -629,82 +638,133 @@ async def get_inventory_alerts(db: Session = Depends(get_db)):
         )
 
         if not snapshots:
-            return {"alerts": []}
+            return {"alerts": [], "alert_mode": "no_data", "message": "No hay datos de inventario."}
 
-        # Get next 90 days of predictions per SKU
-        # Anchor to data timeline (not date.today()) so historical CSVs work correctly
-        from datetime import timedelta
-        from sqlalchemy import func as sqlfunc
+        # ------------------------------------------------------------------
+        # Determine alert mode: forecast or historical fallback
+        # ------------------------------------------------------------------
         min_forecast_date = (
             db.query(sqlfunc.min(Prediction.forecast_date))
             .filter(Prediction.company_id == company.id)
             .scalar()
         )
-        if not min_forecast_date:
-            return {"alerts": []}
 
-        forecast_start = min_forecast_date
-        forecast_end   = min_forecast_date + timedelta(days=90)
+        alert_mode = "forecast" if min_forecast_date else "historical"
 
-        predictions = (
-            db.query(Prediction)
-            .filter(
-                Prediction.company_id == company.id,
-                Prediction.forecast_date >= forecast_start,
-                Prediction.forecast_date <= forecast_end,
+        # ------------------------------------------------------------------
+        # Build avg_daily_demand per SKU depending on mode
+        # ------------------------------------------------------------------
+        avg_demand_by_sku: dict[str, float] = {}
+        reference_date = None  # used to project stockout_date
+
+        if alert_mode == "forecast":
+            forecast_start = min_forecast_date
+            forecast_end   = min_forecast_date + timedelta(days=90)
+            reference_date = forecast_start
+
+            predictions = (
+                db.query(Prediction)
+                .filter(
+                    Prediction.company_id == company.id,
+                    Prediction.forecast_date >= forecast_start,
+                    Prediction.forecast_date <= forecast_end,
+                )
+                .all()
             )
-            .all()
-        )
 
-        # Build dict: item_id → list of predicted_demand values
-        forecast_by_sku: dict[str, list[float]] = {}
-        for p in predictions:
-            forecast_by_sku.setdefault(p.item_id, []).append(float(p.predicted_demand))
+            demand_lists: dict[str, list[float]] = {}
+            for p in predictions:
+                demand_lists.setdefault(p.item_id, []).append(float(p.predicted_demand))
 
+            avg_demand_by_sku = {
+                item_id: sum(vals) / len(vals)
+                for item_id, vals in demand_lists.items()
+                if vals
+            }
+
+        else:
+            # Historical fallback: reuse days_of_stock already stored in inventory_analysis.
+            # avg_daily_demand = inventory_on_hand / days_of_stock (reverse formula).
+            snapshot_ids = [s.id for s in snapshots]
+            analyses = (
+                db.query(InventoryAnalysis)
+                .filter(InventoryAnalysis.inventory_snapshot_id.in_(snapshot_ids))
+                .all()
+            )
+            analysis_by_snapshot = {a.inventory_snapshot_id: a for a in analyses}
+
+            max_sale_date = (
+                db.query(sqlfunc.max(SalesTransaction.date))
+                .filter(SalesTransaction.company_id == company.id)
+                .scalar()
+            )
+            reference_date = max_sale_date
+
+            for snap in snapshots:
+                analysis = analysis_by_snapshot.get(snap.id)
+                if analysis and analysis.days_of_stock and analysis.days_of_stock > 0:
+                    available = snap.inventory_available if snap.inventory_available is not None else snap.inventory_on_hand
+                    avg_demand_by_sku[snap.item_id] = available / float(analysis.days_of_stock)
+
+        # ------------------------------------------------------------------
+        # Build alerts
+        # ------------------------------------------------------------------
         alerts = []
         for snap in snapshots:
-            demands = forecast_by_sku.get(snap.item_id, [])
+            avg_daily_demand = avg_demand_by_sku.get(snap.item_id)
+            if not avg_daily_demand or avg_daily_demand <= 0:
+                continue
+
             available = snap.inventory_available if snap.inventory_available is not None else snap.inventory_on_hand
             lead_time = snap.lead_time_days
 
-            if not demands:
-                # No forecast available for this SKU — skip
-                continue
-
-            avg_daily_demand = sum(demands) / len(demands)
-
-            if avg_daily_demand <= 0:
-                continue
-
-            days_of_stock = available / avg_daily_demand
+            days_of_stock          = available / avg_daily_demand
             demand_during_lead_time = avg_daily_demand * lead_time
 
-            # Determine stock status
             if available <= demand_during_lead_time:
                 stock_status = "critical"
             elif available <= demand_during_lead_time * 1.5:
                 stock_status = "low"
             else:
-                stock_status = "ok"
+                continue  # ok — skip
 
-            if stock_status in ("critical", "low"):
-                stockout_date = forecast_start + timedelta(days=int(days_of_stock))
-                alerts.append({
-                    "item_id": snap.item_id,
-                    "store_id": snap.store_id,
-                    "current_stock": available,
-                    "lead_time_days": lead_time,
-                    "avg_daily_demand": round(avg_daily_demand, 2),
-                    "demand_during_lead_time": round(demand_during_lead_time, 2),
-                    "days_of_stock": round(days_of_stock, 1),
-                    "stockout_date": stockout_date.isoformat(),
-                    "stock_status": stock_status,
-                })
+            # Units to order: cover lead-time demand + 25% safety buffer, minus current stock
+            units_to_order = max(
+                math.ceil(demand_during_lead_time * 1.25 - available),
+                snap.reorder_quantity or 0,
+            )
 
-        # Sort by urgency: critical first, then by days_of_stock ascending
+            stockout_date = (
+                (reference_date + timedelta(days=int(days_of_stock))).isoformat()
+                if reference_date else None
+            )
+
+            alerts.append({
+                "item_id": snap.item_id,
+                "store_id": snap.store_id,
+                "current_stock": available,
+                "lead_time_days": lead_time,
+                "avg_daily_demand": round(avg_daily_demand, 2),
+                "demand_during_lead_time": round(demand_during_lead_time, 2),
+                "days_of_stock": round(days_of_stock, 1),
+                "stockout_date": stockout_date,
+                "stock_status": stock_status,
+                "units_to_order": units_to_order,
+            })
+
         alerts.sort(key=lambda x: (0 if x["stock_status"] == "critical" else 1, x["days_of_stock"]))
 
-        return {"alerts": alerts}
+        mode_message = (
+            "Alertas basadas en demanda proyectada por el modelo de pronóstico (Prophet)."
+            if alert_mode == "forecast"
+            else "No hay pronóstico disponible. Alertas estimadas a partir de ventas históricas."
+        )
+
+        return {
+            "alerts": alerts,
+            "alert_mode": alert_mode,
+            "message": mode_message,
+        }
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error calculating stockout alerts: {e}")

--- a/frontend/src/app/inventory/page.tsx
+++ b/frontend/src/app/inventory/page.tsx
@@ -5,21 +5,28 @@ import axios from "axios"
 import { DashboardLayout } from "@/components/dashboard-layout"
 import { InventoryTable } from "@/components/tables/InventoryTable"
 import { Skeleton } from "@/components/ui/skeleton"
-import { getInventory, type InventoryItem } from "@/lib/api"
+import { getInventory, getInventoryAlerts, type InventoryItem, type StockoutAlert, type AlertMode } from "@/lib/api"
 import { PackageX, ShoppingCart, TrendingDown, DollarSign } from "lucide-react"
 
 type LoadState = "loading" | "ready" | "empty" | "error"
 
 export default function InventoryPage() {
-  const [items, setItems] = useState<InventoryItem[]>([])
-  const [state, setState] = useState<LoadState>("loading")
-  const [errorMsg, setErrorMsg] = useState("")
+  const [items, setItems]         = useState<InventoryItem[]>([])
+  const [alerts, setAlerts]       = useState<StockoutAlert[]>([])
+  const [alertMode, setAlertMode] = useState<AlertMode>("no_data")
+  const [state, setState]         = useState<LoadState>("loading")
+  const [errorMsg, setErrorMsg]   = useState("")
 
   useEffect(() => {
-    getInventory()
-      .then((data) => {
-        setItems(data.items)
-        setState(data.items.length === 0 ? "empty" : "ready")
+    Promise.all([
+      getInventory(),
+      getInventoryAlerts().catch(() => ({ alerts: [], alert_mode: "no_data" as AlertMode, message: "" })),
+    ])
+      .then(([invData, alertData]) => {
+        setItems(invData.items)
+        setAlerts(alertData.alerts)
+        setAlertMode(alertData.alert_mode)
+        setState(invData.items.length === 0 ? "empty" : "ready")
       })
       .catch((err) => {
         if (axios.isAxiosError(err) && err.response?.status === 404) {
@@ -103,9 +110,9 @@ export default function InventoryPage() {
               }
               sub="en inventario sin rotación"
               icon={<DollarSign className="h-5 w-5" />}
-              iconColor={totalImmobilized > 0 ? "text-warning" : "text-muted-foreground"}
-              iconBg={totalImmobilized > 0 ? "bg-warning/10" : "bg-muted"}
-              highlight={totalImmobilized > 0 ? "warning" : undefined}
+              iconColor={totalImmobilized > 0 ? "text-violet-500" : "text-muted-foreground"}
+              iconBg={totalImmobilized > 0 ? "bg-violet-500/10" : "bg-muted"}
+              highlight={totalImmobilized > 0 ? "violet" : undefined}
             />
           </>
         )}
@@ -120,7 +127,7 @@ export default function InventoryPage() {
             ))}
           </div>
         )}
-        {state === "ready" && <InventoryTable items={items} />}
+        {state === "ready" && <InventoryTable items={items} alerts={alerts} alertMode={alertMode} />}
         {state === "empty" && (
           <div className="flex flex-col items-center gap-3 rounded-xl border border-dashed py-16 text-center">
             <p className="text-muted-foreground">No hay datos de inventario disponibles.</p>
@@ -139,6 +146,7 @@ export default function InventoryPage() {
           </div>
         )}
       </section>
+
     </DashboardLayout>
   )
 }
@@ -158,7 +166,7 @@ function StatCard({
   icon: React.ReactNode
   iconColor: string
   iconBg: string
-  highlight?: "destructive" | "warning"
+  highlight?: "destructive" | "warning" | "violet"
 }) {
   return (
     <div className="rounded-xl border bg-card p-5 shadow-sm">
@@ -174,6 +182,8 @@ function StatCard({
             ? "mt-2 text-2xl font-bold text-destructive"
             : highlight === "warning"
             ? "mt-2 text-2xl font-bold text-warning"
+            : highlight === "violet"
+            ? "mt-2 text-2xl font-bold text-violet-500"
             : "mt-2 text-2xl font-bold tracking-tight text-card-foreground"
         }
       >

--- a/frontend/src/components/alerts-table.tsx
+++ b/frontend/src/components/alerts-table.tsx
@@ -1,108 +1,283 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
-import { AlertTriangle, ArrowDown, TrendingDown } from "lucide-react"
-import { getInventoryAlerts, type StockoutAlert } from "@/lib/api"
+import { AlertTriangle, TrendingDown, BarChart2, History, ShoppingCart, HelpCircle } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { getInventoryAlerts, type StockoutAlert, type AlertMode } from "@/lib/api"
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card"
+
+// ---------------------------------------------------------------------------
+// Alerts guide popover — explains how to read stockout alerts
+// ---------------------------------------------------------------------------
+
+function GuideRow({ dot, label, desc }: { dot: string; label: string; desc: string }) {
+  return (
+    <div className="flex items-start gap-2">
+      <span className={`mt-0.5 inline-block h-2 w-2 shrink-0 rounded-full ${dot}`} />
+      <div className="min-w-0">
+        <span className="font-medium text-foreground">{label}</span>
+        <span className="text-muted-foreground"> — {desc}</span>
+      </div>
+    </div>
+  )
+}
+
+function ColRow({ label, desc }: { label: string; desc: string }) {
+  return (
+    <div className="flex gap-2">
+      <span className="w-32 shrink-0 font-medium text-foreground">{label}</span>
+      <span className="text-muted-foreground">{desc}</span>
+    </div>
+  )
+}
+
+function AlertsGuide() {
+  return (
+    <HoverCard openDelay={200} closeDelay={100}>
+      <HoverCardTrigger asChild>
+        <button
+          className="flex h-5 w-5 items-center justify-center rounded-full text-muted-foreground hover:text-foreground transition-colors"
+          aria-label="Cómo interpretar las alertas"
+        >
+          <HelpCircle className="h-4 w-4" />
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent align="start" className="w-96 p-4 text-xs space-y-4">
+        <p className="text-sm font-semibold text-foreground">Cómo leer las alertas</p>
+
+        {/* Estados */}
+        <div className="space-y-1.5">
+          <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">Estados</p>
+          <GuideRow dot="bg-destructive" label="Crítico"   desc="El stock se acaba antes de que llegue el próximo pedido. Actúa hoy." />
+          <GuideRow dot="bg-warning"     label="Atención"  desc="El stock es muy ajustado para el lead time. Programa el pedido pronto." />
+        </div>
+
+        {/* Columnas */}
+        <div className="space-y-1.5">
+          <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">Columnas</p>
+          <ColRow label="Días hasta sin stock" desc="Días que quedan antes de que el producto se agote al ritmo de demanda proyectada." />
+          <ColRow label="Sin stock ~fecha"     desc="Fecha estimada en que el producto se quedará sin stock si no se pide." />
+          <ColRow label="Stock / Demanda"      desc="Unidades disponibles vs las que se necesitan durante el lead time." />
+          <ColRow label="Sugerido a pedir"     desc="Cuánto pedir para no quedarte sin producto antes del próximo pedido. Ej: 600 proyectadas × 1.25 − 137 en bodega = ~613 uds." />
+        </div>
+
+        {/* Cálculo sugerido */}
+        <div className="rounded-md bg-muted/60 px-3 py-2 space-y-2">
+          <p className="font-semibold text-foreground">¿Cuánto pedir para no quedarte sin producto?</p>
+          <p className="text-muted-foreground leading-relaxed">
+            Mientras esperas el pedido, tu stock disponible se va vendiendo. Lo que necesitas pedir es lo
+            suficiente para no quedarte sin producto antes de que llegue el camión, más un colchón
+            extra por si las ventas suben.
+          </p>
+          <p className="text-muted-foreground leading-relaxed">
+            Fórmula:{" "}
+            <span className="font-medium text-foreground">(demanda en lead time × 1.25) − stock disponible</span>,
+            donde el 1.25 es el margen de seguridad del 25%.
+          </p>
+          <p className="text-muted-foreground leading-relaxed">
+            Ejemplo: 600 proyectadas × 1.25 = 750 − 137 en bodega ={" "}
+            <span className="font-medium text-foreground">~613 uds a pedir</span>.
+          </p>
+        </div>
+      </HoverCardContent>
+    </HoverCard>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Alert mode banner
+// ---------------------------------------------------------------------------
+
+function AlertModeBanner({ mode, message }: { mode: AlertMode; message: string }) {
+  if (mode === "no_data") return null
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 rounded-lg px-3 py-2 text-xs mb-3",
+        mode === "forecast"
+          ? "bg-primary/8 text-primary border border-primary/20"
+          : "bg-warning/8 text-warning border border-warning/20"
+      )}
+    >
+      {mode === "forecast"
+        ? <BarChart2 className="h-3.5 w-3.5 shrink-0" />
+        : <History className="h-3.5 w-3.5 shrink-0" />
+      }
+      <span>{message}</span>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Single alert row
+// ---------------------------------------------------------------------------
+
+function AlertRow({ alert }: { alert: StockoutAlert }) {
+  const isCritical = alert.stock_status === "critical"
+
+  return (
+    <TableRow
+      className={cn(
+        "transition-colors",
+        isCritical
+          ? "border-l-2 border-l-destructive bg-destructive/5 hover:bg-destructive/10"
+          : "border-l-2 border-l-warning bg-warning/5 hover:bg-warning/10"
+      )}
+    >
+      <TableCell>
+        <Badge
+          variant={isCritical ? "destructive" : "secondary"}
+          className={cn("gap-1", !isCritical && "bg-warning/15 text-warning")}
+        >
+          <AlertTriangle className="h-3 w-3" />
+          {isCritical ? "Crítico" : "Atención"}
+        </Badge>
+      </TableCell>
+
+      <TableCell className="font-medium text-card-foreground">
+        <div className="flex flex-col gap-0.5">
+          <span>{alert.item_id}</span>
+          {alert.store_id && (
+            <span className="text-[10px] text-muted-foreground">{alert.store_id}</span>
+          )}
+        </div>
+      </TableCell>
+
+      <TableCell className="hidden md:table-cell">
+        <div className="flex flex-col gap-0.5">
+          <span className={cn("font-semibold", isCritical ? "text-destructive" : "text-warning")}>
+            {alert.days_of_stock} días
+          </span>
+          {alert.stockout_date && (
+            <span className="text-[10px] text-muted-foreground">
+              Sin stock ~{new Date(alert.stockout_date).toLocaleDateString("es-CO", {
+                day: "numeric", month: "short"
+              })}
+            </span>
+          )}
+        </div>
+      </TableCell>
+
+      <TableCell className="hidden lg:table-cell text-muted-foreground text-sm">
+        {alert.current_stock.toLocaleString()} uds disponibles
+        <span className="block text-[10px] text-muted-foreground/70">
+          Demanda en {alert.lead_time_days}d: ~{Math.ceil(alert.demand_during_lead_time)} uds
+        </span>
+      </TableCell>
+
+      <TableCell className="text-right">
+        <div className="flex items-center justify-end gap-1">
+          <ShoppingCart className="h-3.5 w-3.5 text-primary shrink-0" />
+          <span className="font-semibold text-primary">
+            ~{alert.units_to_order.toLocaleString()} uds
+          </span>
+        </div>
+        <span className="block text-[10px] text-right text-muted-foreground">
+          sugerido a pedir
+        </span>
+      </TableCell>
+    </TableRow>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
 
 export function AlertsTable() {
-  const [alerts, setAlerts] = useState<StockoutAlert[]>([])
-  const [loading, setLoading] = useState(true)
+  const [alerts, setAlerts]       = useState<StockoutAlert[]>([])
+  const [alertMode, setAlertMode] = useState<AlertMode>("no_data")
+  const [modeMessage, setModeMessage] = useState("")
+  const [loading, setLoading]     = useState(true)
   const [refreshKey, setRefreshKey] = useState(0)
 
   useEffect(() => {
     const handler = () => setRefreshKey((k) => k + 1)
     window.addEventListener("pipeline:dataready", handler)
-    return () => window.removeEventListener("pipeline:dataready", handler)
+    window.addEventListener("pipeline:refetch", handler)
+    return () => {
+      window.removeEventListener("pipeline:dataready", handler)
+      window.removeEventListener("pipeline:refetch", handler)
+    }
   }, [])
 
   useEffect(() => {
     setLoading(true)
     getInventoryAlerts()
-      .then((res) => setAlerts(res.alerts))
-      .catch(() => setAlerts([]))
+      .then((res) => {
+        setAlerts(res.alerts)
+        setAlertMode(res.alert_mode)
+        setModeMessage(res.message)
+      })
+      .catch(() => {
+        setAlerts([])
+        setAlertMode("no_data")
+      })
       .finally(() => setLoading(false))
   }, [refreshKey])
+
+  const criticalCount = alerts.filter((a) => a.stock_status === "critical").length
 
   return (
     <Card className="bg-card">
       <CardHeader>
         <CardTitle className="flex items-center gap-2 text-card-foreground">
           <AlertTriangle className="h-5 w-5 text-warning" />
-          Alertas de Stockout
+          Alertas de Quiebre de Stock
+          <AlertsGuide />
+          {alerts.length > 0 && (
+            <Badge variant="secondary" className="ml-auto bg-warning/10 text-warning">
+              {alerts.length} activas
+            </Badge>
+          )}
         </CardTitle>
+        {criticalCount > 0 && (
+          <CardDescription className="text-destructive font-medium">
+            {criticalCount} SKU{criticalCount > 1 ? "s" : ""} en estado crítico — requieren acción inmediata
+          </CardDescription>
+        )}
       </CardHeader>
+
       <CardContent>
         {loading ? (
           <div className="flex flex-col gap-3">
             {Array.from({ length: 4 }).map((_, i) => (
-              <Skeleton key={i} className="h-10 w-full" />
+              <Skeleton key={i} className="h-12 w-full rounded-lg" />
             ))}
           </div>
         ) : alerts.length === 0 ? (
-          <p className="py-6 text-center text-sm text-muted-foreground">
-            Sin alertas activas — todos los SKUs tienen stock suficiente para cubrir su lead time.
-          </p>
+          <div className="py-8 text-center">
+            <TrendingDown className="mx-auto h-8 w-8 text-muted-foreground/40 mb-2" />
+            <p className="text-sm text-muted-foreground">
+              Sin alertas activas — todos los SKUs tienen stock suficiente.
+            </p>
+          </div>
         ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Estado</TableHead>
-                <TableHead>SKU</TableHead>
-                <TableHead className="hidden md:table-cell">Stock disponible</TableHead>
-                <TableHead className="hidden md:table-cell">Demanda en lead time</TableHead>
-                <TableHead className="text-right">Días a stockout</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {alerts.map((alert) => (
-                <TableRow key={alert.item_id}>
-                  <TableCell>
-                    <Badge
-                      variant={alert.stock_status === "critical" ? "destructive" : "secondary"}
-                      className={
-                        alert.stock_status === "low"
-                          ? "bg-warning text-warning-foreground"
-                          : ""
-                      }
-                    >
-                      {alert.stock_status === "critical" ? "Crítico" : "Atención"}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="font-medium text-card-foreground">
-                    {alert.item_id}
-                  </TableCell>
-                  <TableCell className="hidden text-muted-foreground md:table-cell">
-                    {alert.current_stock.toLocaleString()} uds
-                  </TableCell>
-                  <TableCell className="hidden text-muted-foreground md:table-cell">
-                    {alert.demand_during_lead_time.toFixed(0)} uds ({alert.lead_time_days}d)
-                  </TableCell>
-                  <TableCell className="text-right">
-                    <span className="flex items-center justify-end gap-1">
-                      {alert.days_of_stock <= 7 ? (
-                        <ArrowDown className="h-3.5 w-3.5 text-destructive" />
-                      ) : (
-                        <TrendingDown className="h-3.5 w-3.5 text-muted-foreground" />
-                      )}
-                      <span
-                        className={
-                          alert.days_of_stock <= 7
-                            ? "font-semibold text-destructive"
-                            : "text-muted-foreground"
-                        }
-                      >
-                        {alert.days_of_stock} días
-                      </span>
-                    </span>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+          <>
+            <AlertModeBanner mode={alertMode} message={modeMessage} />
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow className="text-xs uppercase tracking-wide">
+                    <TableHead>Estado</TableHead>
+                    <TableHead>SKU</TableHead>
+                    <TableHead className="hidden md:table-cell">Días hasta sin stock</TableHead>
+                    <TableHead className="hidden lg:table-cell">Stock / Demanda</TableHead>
+                    <TableHead className="text-right">Pedir</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {alerts.map((alert) => (
+                    <AlertRow key={`${alert.item_id}-${alert.store_id}`} alert={alert} />
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          </>
         )}
       </CardContent>
     </Card>

--- a/frontend/src/components/dashboard-layout.tsx
+++ b/frontend/src/components/dashboard-layout.tsx
@@ -6,7 +6,71 @@ import { useEffect, useRef, useState, useCallback, type ReactNode } from "react"
 import { AppSidebar } from "@/components/app-sidebar"
 import { NotificationBell } from "@/components/notification-bell"
 import { PipelineToast } from "@/components/pipeline-toast"
-import { getPredictionsStatus, type PredictionsStatus } from "@/lib/api"
+import { getPredictionsStatus, getInventoryAlerts, type PredictionsStatus } from "@/lib/api"
+import { AlertTriangle, X } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { cn } from "@/lib/utils"
+
+// ---------------------------------------------------------------------------
+// Inventory alert toast — shown globally on every page via DashboardLayout
+// ---------------------------------------------------------------------------
+function InventoryAlertToast({
+  criticalCount,
+  totalCount,
+  visible,
+  abovePipeline,
+  onDismiss,
+}: {
+  criticalCount: number
+  totalCount: number
+  visible: boolean
+  abovePipeline: boolean
+  onDismiss: () => void
+}) {
+  if (!visible || totalCount === 0) return null
+  return (
+    <div
+      className={cn(
+        "fixed right-4 z-50 pointer-events-none transition-all duration-300",
+        abovePipeline ? "bottom-24" : "bottom-4",
+      )}
+    >
+      <Card className="w-80 shadow-lg border-destructive/30 pointer-events-auto py-0 animate-in slide-in-from-bottom-4 fade-in duration-300">
+        <CardContent className="px-4 py-3">
+          <div className="flex items-start gap-3">
+            <div className="shrink-0 mt-0.5">
+              <AlertTriangle
+                className={cn("h-5 w-5", criticalCount > 0 ? "text-destructive" : "text-orange-500")}
+              />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-foreground">
+                {criticalCount > 0
+                  ? `${criticalCount} SKU${criticalCount > 1 ? "s" : ""} en riesgo crítico de stockout`
+                  : `${totalCount} SKU${totalCount > 1 ? "s" : ""} con riesgo de stockout`}
+              </p>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                {criticalCount > 0 && totalCount > criticalCount
+                  ? `+${totalCount - criticalCount} en atención · `
+                  : ""}
+                Revisa{" "}
+                <a href="/inventory" className="font-medium text-foreground underline underline-offset-2">
+                  Inventario → Riesgo Stockout
+                </a>
+              </p>
+            </div>
+            <button
+              onClick={onDismiss}
+              className="shrink-0 text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
 
 interface DashboardLayoutProps {
   children: ReactNode
@@ -31,8 +95,40 @@ export function DashboardLayout({ children, title, subtitle, showLastRunAt }: Da
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const autoDismissRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
+  // Inventory alert notification state
+  const [invAlertTotal, setInvAlertTotal]       = useState(0)
+  const [invAlertCritical, setInvAlertCritical] = useState(0)
+  const [invToastVisible, setInvToastVisible]   = useState(false)
+  const [invToastDismissed, setInvToastDismissed] = useState(false)
+  const invAutoDismissRef  = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const invProgressiveRef  = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Ref-mirror so fetchInventoryAlerts closure doesn't go stale
+  const invDismissedRef = useRef(false)
+
   const stopPolling = useCallback(() => {
     if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null }
+  }, [])
+
+  // ------------------------------------------------------------------
+  // Inventory alert fetch — runs on mount and on pipeline:dataready
+  // ------------------------------------------------------------------
+  const fetchInventoryAlerts = useCallback(async () => {
+    try {
+      const data = await getInventoryAlerts()
+      const total    = data.alerts.length
+      const critical = data.alerts.filter((a) => a.stock_status === "critical").length
+      setInvAlertTotal(total)
+      setInvAlertCritical(critical)
+
+      if (total > 0 && !invDismissedRef.current) {
+        setInvToastVisible(true)
+        // Auto-dismiss after 15 s
+        if (invAutoDismissRef.current) clearTimeout(invAutoDismissRef.current)
+        invAutoDismissRef.current = setTimeout(() => setInvToastVisible(false), 15000)
+      }
+    } catch {
+      // Silent — don't break layout if inventory endpoint is unavailable
+    }
   }, [])
 
   const fetchStatus = useCallback(async () => {
@@ -78,7 +174,7 @@ export function DashboardLayout({ children, title, subtitle, showLastRunAt }: Da
     }
   }, [stopPolling])
 
-  // Initial fetch on mount
+  // Initial fetch on mount — pipeline status
   useEffect(() => {
     fetchStatus()
     return () => {
@@ -87,7 +183,33 @@ export function DashboardLayout({ children, title, subtitle, showLastRunAt }: Da
     }
   }, [fetchStatus, stopPolling])
 
-  // Listen for trigger from data-ingestion page after upload
+  // Initial fetch on mount — inventory alerts
+  // 150ms delay so the first render paints before the toast slides in
+  useEffect(() => {
+    const t = setTimeout(fetchInventoryAlerts, 150)
+    return () => {
+      clearTimeout(t)
+      if (invAutoDismissRef.current) clearTimeout(invAutoDismissRef.current)
+      if (invProgressiveRef.current)  clearTimeout(invProgressiveRef.current)
+    }
+  }, [fetchInventoryAlerts])
+
+  // Re-fetch inventory alerts whenever pipeline finishes or data is refreshed
+  useEffect(() => {
+    const handler = () => {
+      invDismissedRef.current = false   // new data → allow toast again
+      setInvToastDismissed(false)
+      fetchInventoryAlerts()
+    }
+    window.addEventListener("pipeline:dataready", handler)
+    window.addEventListener("pipeline:refetch",   handler)
+    return () => {
+      window.removeEventListener("pipeline:dataready", handler)
+      window.removeEventListener("pipeline:refetch",   handler)
+    }
+  }, [fetchInventoryAlerts])
+
+  // Listen for trigger from data-ingestion page after upload — pipeline
   useEffect(() => {
     const handler = () => fetchStatus()
     window.addEventListener("pipeline:refetch", handler)
@@ -139,8 +261,26 @@ export function DashboardLayout({ children, title, subtitle, showLastRunAt }: Da
                 </span>
               )}
               <NotificationBell
-                hasActiveNotification={(pipelineStatus === "processing" || pipelineStatus === "uploaded" || pipelineStatus === "failed") && toastDismissed}
-                onClick={() => { setToastDismissed(false); setToastVisible(true) }}
+                hasActiveNotification={
+                  (pipelineStatus === "processing" || pipelineStatus === "uploaded" || pipelineStatus === "failed") &&
+                  toastDismissed
+                }
+                inventoryAlertCount={invAlertTotal}
+                onClick={() => {
+                  // Bell click → re-show inventory alert toast (primary) …
+                  if (invAlertTotal > 0) {
+                    invDismissedRef.current = false
+                    setInvToastDismissed(false)
+                    setInvToastVisible(true)
+                    if (invAutoDismissRef.current) clearTimeout(invAutoDismissRef.current)
+                    invAutoDismissRef.current = setTimeout(() => setInvToastVisible(false), 15000)
+                  }
+                  // … and re-show pipeline toast if applicable
+                  if (pipelineStatus !== "no_data" && pipelineStatus !== "ready") {
+                    setToastDismissed(false)
+                    setToastVisible(true)
+                  }
+                }}
               />
             </div>
           </div>
@@ -153,6 +293,18 @@ export function DashboardLayout({ children, title, subtitle, showLastRunAt }: Da
         visible={toastVisible}
         lastRunAt={lastRunAt ?? undefined}
         onDismiss={() => { setToastVisible(false); setToastDismissed(true) }}
+      />
+
+      <InventoryAlertToast
+        criticalCount={invAlertCritical}
+        totalCount={invAlertTotal}
+        visible={invToastVisible && !invToastDismissed}
+        abovePipeline={toastVisible && !toastDismissed}
+        onDismiss={() => {
+          setInvToastVisible(false)
+          setInvToastDismissed(true)
+          invDismissedRef.current = true
+        }}
       />
     </div>
   )

--- a/frontend/src/components/notification-bell.tsx
+++ b/frontend/src/components/notification-bell.tsx
@@ -3,11 +3,17 @@
 import { Bell } from "lucide-react"
 
 interface NotificationBellProps {
+  /** Shows a pulsing dot for pipeline status (processing / failed) */
   hasActiveNotification: boolean
+  /** Shows a numeric badge for inventory stockout alerts */
+  inventoryAlertCount?: number
   onClick: () => void
 }
 
-export function NotificationBell({ hasActiveNotification, onClick }: NotificationBellProps) {
+export function NotificationBell({ hasActiveNotification, inventoryAlertCount = 0, onClick }: NotificationBellProps) {
+  const showCount  = inventoryAlertCount > 0
+  const showDot    = !showCount && hasActiveNotification
+
   return (
     <button
       onClick={onClick}
@@ -15,9 +21,19 @@ export function NotificationBell({ hasActiveNotification, onClick }: Notificatio
       className="relative flex h-9 w-9 items-center justify-center rounded-full text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
     >
       <Bell className="h-4 w-4" />
-      {hasActiveNotification && (
+
+      {/* Numeric badge — inventory stockout alerts */}
+      {showCount && (
+        <span className="absolute -top-0.5 -right-0.5 flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-destructive px-1 text-[9px] font-bold leading-none text-white">
+          {inventoryAlertCount > 9 ? "9+" : inventoryAlertCount}
+        </span>
+      )}
+
+      {/* Dot — pipeline activity only */}
+      {showDot && (
         <span className="absolute top-0.5 right-0.5 h-2 w-2 rounded-full bg-destructive" />
       )}
+
       <span className="sr-only">Notificaciones</span>
     </button>
   )

--- a/frontend/src/components/tables/InventoryTable.tsx
+++ b/frontend/src/components/tables/InventoryTable.tsx
@@ -6,9 +6,10 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Search, AlertTriangle, TrendingDown, CheckCircle2, Skull } from "lucide-react"
+import { Search, AlertTriangle, TrendingDown, CheckCircle2, Skull, BarChart2, History, HelpCircle } from "lucide-react"
 import { cn } from "@/lib/utils"
-import type { InventoryItem } from "@/lib/api"
+import type { InventoryItem, StockoutAlert, AlertMode } from "@/lib/api"
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card"
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -18,7 +19,9 @@ function isBelowReorder(item: InventoryItem): boolean {
   return item.reorder_point != null && item.current_stock <= item.reorder_point
 }
 
-function StockStatusBadge({ item }: { item: InventoryItem }) {
+// isAlert = item appears in backend stockout-alert list
+function StockStatusBadge({ item, isAlert }: { item: InventoryItem; isAlert: boolean }) {
+  // Priority: Reordenar > Stock Muerto > Atención (stockout risk) > Mov. Lento > OK > Pendiente
   if (isBelowReorder(item)) {
     return (
       <Badge variant="destructive" className="gap-1">
@@ -35,6 +38,16 @@ function StockStatusBadge({ item }: { item: InventoryItem }) {
       </Badge>
     )
   }
+  // Orange — stockout risk (forecast demand will exceed stock during lead time)
+  if (isAlert) {
+    return (
+      <Badge variant="secondary" className="gap-1 bg-orange-500/10 text-orange-500">
+        <AlertTriangle className="h-3 w-3" />
+        Atención
+      </Badge>
+    )
+  }
+  // Amber — slow-moving (high days-of-stock but no imminent stockout)
   if (item.slow_moving_flag === true) {
     return (
       <Badge variant="secondary" className="gap-1 bg-warning/10 text-warning">
@@ -73,6 +86,86 @@ function ReorderCell({ item }: { item: InventoryItem }) {
 }
 
 // ---------------------------------------------------------------------------
+// Inventory guide popover — explains badges and columns
+// ---------------------------------------------------------------------------
+
+function Dot({ color }: { color: string }) {
+  return <span className={`inline-block h-2 w-2 rounded-full shrink-0 ${color}`} />
+}
+
+function GuideRow({ dot, label, desc }: { dot: string; label: string; desc: string }) {
+  return (
+    <div className="flex items-start gap-2">
+      <Dot color={dot} />
+      <div className="min-w-0">
+        <span className="font-medium text-foreground">{label}</span>
+        <span className="text-muted-foreground"> — {desc}</span>
+      </div>
+    </div>
+  )
+}
+
+function ColRow({ label, desc }: { label: string; desc: string }) {
+  return (
+    <div className="flex gap-2">
+      <span className="w-28 shrink-0 font-medium text-foreground">{label}</span>
+      <span className="text-muted-foreground">{desc}</span>
+    </div>
+  )
+}
+
+function InventoryGuide() {
+  return (
+    <HoverCard openDelay={200} closeDelay={100}>
+      <HoverCardTrigger asChild>
+        <button
+          className="flex h-5 w-5 items-center justify-center rounded-full text-muted-foreground hover:text-foreground transition-colors"
+          aria-label="Cómo interpretar el inventario"
+        >
+          <HelpCircle className="h-4 w-4" />
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent align="start" className="w-96 p-4 text-xs space-y-4">
+        {/* Header */}
+        <p className="text-sm font-semibold text-foreground">Cómo leer el inventario</p>
+
+        {/* Estados */}
+        <div className="space-y-1.5">
+          <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">Estados</p>
+          <GuideRow dot="bg-destructive"    label="Reordenar"    desc="Stock ≤ punto de reorden. Actúa hoy." />
+          <GuideRow dot="bg-orange-500"     label="Atención"     desc="La demanda proyectada durante el lead time supera el stock. Riesgo de quedarse sin stock antes del próximo pedido." />
+          <GuideRow dot="bg-warning"        label="Mov. Lento"   desc="Más de 90 días de stock acumulado. El producto rota poco." />
+          <GuideRow dot="bg-destructive/60" label="Stock Muerto" desc="Más de 180 días de stock. Sin rotación significativa." />
+          <GuideRow dot="bg-success"        label="OK"           desc="Stock suficiente y rotación normal." />
+        </div>
+
+        {/* Columnas */}
+        <div className="space-y-1.5">
+          <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">Columnas clave</p>
+          <ColRow label="Días Stock"     desc="Cuántos días dura el stock al ritmo histórico de ventas." />
+          <ColRow label="Pto. Reorden"   desc="Umbral mínimo antes de pedir = demanda diaria × lead time." />
+          <ColRow label="Lead Time"      desc="Días que tarda en llegar un nuevo pedido al almacén." />
+          <ColRow label="Pronóstico/mes" desc="Demanda proyectada por el modelo para el próximo mes." />
+        </div>
+
+        {/* Tip clave */}
+        <div className="rounded-md bg-muted/60 px-3 py-2 space-y-1">
+          <p className="font-semibold text-foreground">Atención ≠ Días Stock bajos</p>
+          <p className="text-muted-foreground leading-relaxed">
+            Un SKU con pocos días de stock puede ser{" "}
+            <span className="text-success font-medium">OK</span> si sus unidades cubren
+            la demanda durante el lead time.{" "}
+            <span className="text-orange-500 font-medium">Atención</span> se activa cuando
+            el stock <em>no alcanza</em> para esperar el próximo pedido — aunque los días
+            de stock parezcan suficientes.
+          </p>
+        </div>
+      </HoverCardContent>
+    </HoverCard>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Filter tabs
 // ---------------------------------------------------------------------------
 
@@ -90,7 +183,7 @@ function FilterTabs({ active, counts, onChange }: FilterTabProps) {
     { key: "reorder",label: "Por Reordenar",   count: counts.reorder},
     { key: "slow",   label: "Movimiento Lento",count: counts.slow   },
     { key: "dead",   label: "Stock Muerto",    count: counts.dead   },
-    { key: "alerts", label: "Alertas",         count: counts.alerts },
+    { key: "alerts", label: "Riesgo Sin Stock", count: counts.alerts },
   ]
 
   return (
@@ -134,16 +227,20 @@ function FilterTabs({ active, counts, onChange }: FilterTabProps) {
 
 interface InventoryTableProps {
   items: InventoryItem[]
+  alerts?: StockoutAlert[]
+  alertMode?: AlertMode
 }
 
-export function InventoryTable({ items }: InventoryTableProps) {
+export function InventoryTable({ items, alerts = [], alertMode }: InventoryTableProps) {
   const [search, setSearch]   = useState("")
   const [filter, setFilter]   = useState<FilterType>("all")
+
+  const alertItemIds = new Set(alerts.map((a) => a.item_id))
 
   const reorderItems  = items.filter(isBelowReorder)
   const slowItems     = items.filter((i) => i.slow_moving_flag === true && i.stock_status !== "dead_stock")
   const deadItems     = items.filter((i) => i.stock_status === "dead_stock")
-  const alertItems = items.filter((i) => i.days_of_stock != null && i.days_of_stock <= i.lead_time_days * 1.5)
+  const alertItems    = items.filter((i) => alertItemIds.has(i.item_id))
 
   const counts = {
     all:     items.length,
@@ -159,7 +256,7 @@ export function InventoryTable({ items }: InventoryTableProps) {
       if (filter === "reorder") return isBelowReorder(i)
       if (filter === "slow")    return i.slow_moving_flag === true && i.stock_status !== "dead_stock"
       if (filter === "dead")    return i.stock_status === "dead_stock"
-      if (filter === "alerts")  return i.days_of_stock != null && i.days_of_stock <= i.lead_time_days * 1.5
+      if (filter === "alerts")  return alertItemIds.has(i.item_id)
       return true
     })
 
@@ -169,7 +266,10 @@ export function InventoryTable({ items }: InventoryTableProps) {
         <div className="flex flex-col gap-3">
           <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
             <div>
-              <CardTitle className="text-card-foreground">Inventario por SKU</CardTitle>
+              <CardTitle className="flex items-center gap-1.5 text-card-foreground">
+                Inventario por SKU
+                <InventoryGuide />
+              </CardTitle>
               <CardDescription>
                 {reorderItems.length > 0 && (
                   <span className="text-destructive font-medium">
@@ -201,6 +301,24 @@ export function InventoryTable({ items }: InventoryTableProps) {
           </div>
 
           <FilterTabs active={filter} counts={counts} onChange={setFilter} />
+
+          {filter === "alerts" && alertMode && alertMode !== "no_data" && (
+            <div className={cn(
+              "flex items-center gap-2 rounded-lg px-3 py-2 text-xs",
+              alertMode === "forecast"
+                ? "bg-primary/8 text-primary border border-primary/20"
+                : "bg-warning/8 text-warning border border-warning/20"
+            )}>
+              {alertMode === "forecast"
+                ? <BarChart2 className="h-3.5 w-3.5 shrink-0" />
+                : <History className="h-3.5 w-3.5 shrink-0" />
+              }
+              {alertMode === "forecast"
+                ? "Riesgo calculado con demanda proyectada por el modelo de pronóstico (Prophet)."
+                : "Sin pronóstico disponible — riesgo estimado con ventas históricas."
+              }
+            </div>
+          )}
         </div>
       </CardHeader>
 
@@ -238,6 +356,8 @@ export function InventoryTable({ items }: InventoryTableProps) {
                         ? "border-l-2 border-l-destructive bg-destructive/5 hover:bg-destructive/10"
                         : item.stock_status === "dead_stock"
                         ? "border-l-2 border-l-destructive/50 bg-destructive/5 hover:bg-destructive/10"
+                        : alertItemIds.has(item.item_id)
+                        ? "border-l-2 border-l-orange-500 bg-orange-500/5 hover:bg-orange-500/10"
                         : item.slow_moving_flag === true
                         ? "border-l-2 border-l-warning bg-warning/5 hover:bg-warning/10"
                         : "hover:bg-muted/40"
@@ -299,7 +419,7 @@ export function InventoryTable({ items }: InventoryTableProps) {
 
                     {/* Estado */}
                     <TableCell>
-                      <StockStatusBadge item={item} />
+                      <StockStatusBadge item={item} isAlert={alertItemIds.has(item.item_id)} />
                     </TableCell>
                   </TableRow>
                 ))

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -138,12 +138,17 @@ export interface StockoutAlert {
   avg_daily_demand: number
   demand_during_lead_time: number
   days_of_stock: number
-  stockout_date: string
+  stockout_date: string | null
   stock_status: "critical" | "low"
+  units_to_order: number
 }
+
+export type AlertMode = "forecast" | "historical" | "no_data"
 
 export interface AlertsResponse {
   alerts: StockoutAlert[]
+  alert_mode: AlertMode
+  message: string
 }
 
 export function getInventoryAlerts(): Promise<AlertsResponse> {


### PR DESCRIPTION
## Cambios incluidos

### Backend
- `GET /api/inventory/alerts` ahora usa demanda del forecast (Prophet) cuando está disponible, con fallback a ventas históricas cuando no hay predicciones. Devuelve `alert_mode`, `message` y `units_to_order` por SKU.

### Alertas de Quiebre de Stock (dashboard)
- Tabla rediseñada con banner que indica la fuente del cálculo (forecast vs histórico)
- Nueva columna "Sugerido a pedir" con cantidad recomendada por SKU
- Fecha estimada de quiebre de stock por fila
- Ícono `?` con guía hover explicando cómo leer cada columna y cómo se calcula lo sugerido a pedir

### Tabla de Inventario
- Badge naranja **Atención** para SKUs con riesgo de quiebre de stock (distinto del amarillo **Mov. Lento**)
- Resaltado de fila naranja para SKUs en riesgo
- Tab renombrado a **Riesgo Sin Stock** (datos vienen del backend, no cálculo local)
- Ícono `?` con guía hover explicando badges, columnas clave y la diferencia entre Atención y Días Stock bajos

### Notificaciones globales
- Toast de alertas de inventario movido a `DashboardLayout` — aparece en **todas las páginas**
- Auto-dismiss a los 15 segundos
- Campana muestra badge numérico con el total de alertas activas
- Bell click re-abre la toast y reinicia el timer

### Inventario — stat cards
- Card **Capital Inmovilizado** ahora usa color violeta para diferenciarse de **Movimiento Lento** (ambas eran amber)

## User Stories cubiertas
- US-08 Slow-Moving Inventory Detection
- US-10 Reorder Point Calculation  
- US-11 Stockout Alerts & Risk Identification