### PR TITLE
feat(US-13): Model accuracy metrics — MAE, RMSE, MAPE, coverage & bias per SKU

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -15,7 +15,7 @@ from api.validation import validate_sales_dataframe, validate_inventory_datafram
 from demand_forecast.prophet_demand_forecast import run_pipeline
 
 from database.database import get_db, SessionLocal, init_db
-from database.models import Company, DataSource, SalesTransaction, Prediction, InventorySnapshot, InventoryAnalysis
+from database.models import Company, DataSource, SalesTransaction, Prediction, InventorySnapshot, InventoryAnalysis, ModelMetrics
 from inventory.inventory_analysis import run_inventory_analysis
 
 
@@ -421,6 +421,71 @@ async def get_predictions(
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error fetching predictions: {e}")
+
+# =============================================================================
+# GET /api/predictions/metrics
+# =============================================================================
+
+@app.get(
+    "/api/predictions/metrics",
+    tags=["Predictions"],
+    summary="Get Prophet model accuracy metrics",
+    description="Returns aggregate and per-SKU accuracy metrics (MAE, RMSE, MAPE, CI coverage, bias) from the last Prophet training run.",
+)
+async def get_model_metrics(db: Session = Depends(get_db)):
+    try:
+        data_source = (
+            db.query(DataSource)
+            .order_by(DataSource.upload_date.desc())
+            .first()
+        )
+        if not data_source:
+            raise HTTPException(status_code=404, detail="No data uploaded yet.")
+        if data_source.status != "ready":
+            raise HTTPException(status_code=404, detail="Metrics not available yet — pipeline has not completed.")
+
+        company_id = data_source.company_id
+
+        aggregate = (
+            db.query(ModelMetrics)
+            .filter(ModelMetrics.company_id == company_id, ModelMetrics.item_id.is_(None))
+            .order_by(ModelMetrics.created_at.desc())
+            .first()
+        )
+        per_sku = (
+            db.query(ModelMetrics)
+            .filter(ModelMetrics.company_id == company_id, ModelMetrics.item_id.isnot(None))
+            .order_by(ModelMetrics.mape.asc())
+            .all()
+        )
+
+        if not aggregate and not per_sku:
+            raise HTTPException(status_code=404, detail="No metrics computed yet. Re-upload the sales file to trigger training.")
+
+        def _fmt(m):
+            return {
+                "item_id": m.item_id,
+                "mae":          float(m.mae)          if m.mae          is not None else None,
+                "rmse":         float(m.rmse)         if m.rmse         is not None else None,
+                "mape":         float(m.mape)         if m.mape         is not None else None,
+                "coverage_ic":  float(m.coverage_ic)  if m.coverage_ic  is not None else None,
+                "bias":         float(m.bias)         if m.bias         is not None else None,
+                "training_samples":   m.training_samples,
+                "validation_samples": m.validation_samples,
+                "seasonality_mode":   m.seasonality_mode,
+                "last_updated": m.created_at.isoformat() if m.created_at else None,
+            }
+
+        return {
+            "aggregate": _fmt(aggregate) if aggregate else None,
+            "per_sku":   [_fmt(m) for m in per_sku],
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error fetching metrics: {e}")
+
 
 # =============================================================================
 # GET /api/sales/range

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -92,3 +92,26 @@ class InventoryAnalysis(Base):
     stock_status = Column(String(20))  # ok / low / critical
 
     created_at = Column(TIMESTAMP, server_default=text("CURRENT_TIMESTAMP"))
+
+
+class ModelMetrics(Base):
+    """Per-SKU and aggregate accuracy metrics computed after each Prophet training run."""
+    __tablename__ = "model_metrics"
+
+    id         = Column(Integer, primary_key=True)
+    company_id = Column(Integer, ForeignKey("company.id"))
+    item_id    = Column(String(100), nullable=True)    # NULL → aggregate row
+
+    # Core accuracy metrics
+    mae         = Column(Numeric(12, 4))               # Mean Absolute Error (units/day)
+    rmse        = Column(Numeric(12, 4))               # Root Mean Squared Error (units/day)
+    mape        = Column(Numeric(8, 2))                # Mean Absolute Percentage Error (%)
+    coverage_ic = Column(Numeric(8, 2))                # % of actuals inside confidence interval
+    bias        = Column(Numeric(12, 4))               # avg(predicted − actual); + = overforecast
+
+    # Training context
+    training_samples   = Column(Integer)               # rows used for training
+    validation_samples = Column(Integer)               # rows used for validation window
+    seasonality_mode   = Column(String(20))            # 'additive' | 'multiplicative'
+
+    created_at = Column(TIMESTAMP, server_default=text("CURRENT_TIMESTAMP"))

--- a/backend/demand_forecast/prophet_demand_forecast.py
+++ b/backend/demand_forecast/prophet_demand_forecast.py
@@ -18,7 +18,7 @@ sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from sqlalchemy.orm import Session
 from database.database import SessionLocal
-from database.models import Prediction, Company
+from database.models import Prediction, Company, ModelMetrics
 
 warnings.filterwarnings('ignore')
 
@@ -165,6 +165,38 @@ def evaluate(forecast, df_test):
     rmse = np.sqrt(mean_squared_error(real, pred))
     mae_rel = mae / real.mean() * 100
     return mae, rmse, mae_rel
+
+
+def evaluate_full(forecast, df_val):
+    """
+    Extended evaluation: MAE, RMSE, MAPE, confidence-interval coverage, and bias.
+    Works for both out-of-sample test sets and in-sample validation windows.
+    """
+    pred  = forecast.set_index('ds')['yhat'].reindex(df_val['ds'].values)
+    lower = forecast.set_index('ds')['yhat_lower'].reindex(df_val['ds'].values)
+    upper = forecast.set_index('ds')['yhat_upper'].reindex(df_val['ds'].values)
+    real  = df_val.set_index('ds')['y']
+
+    mask = pred.notna() & real.notna()
+    pred, real, lower, upper = pred[mask], real[mask], lower[mask], upper[mask]
+
+    if len(pred) == 0:
+        return None, None, None, None, None
+
+    mae  = float(mean_absolute_error(real, pred))
+    rmse = float(np.sqrt(mean_squared_error(real, pred)))
+
+    # MAPE — skip zero-demand days (avoid division by zero)
+    nz   = real > 0
+    mape = float((abs(real[nz] - pred[nz]) / real[nz]).mean() * 100) if nz.sum() > 0 else None
+
+    # % of actual values inside the confidence interval
+    coverage_ic = float(((real >= lower) & (real <= upper)).mean() * 100)
+
+    # Bias: positive → model overforecasts on average
+    bias = float((pred - real).mean())
+
+    return mae, rmse, mape, coverage_ic, bias
 
 # =============================================================================
 # Section 5: Hyperparameter Tuning (pilot SKU)
@@ -451,6 +483,90 @@ def save_predictions_to_db(forecasts, company_id=1):
         db.close()
 
 # =============================================================================
+# Section 9: Save Model Metrics to Database
+# =============================================================================
+
+def save_model_metrics_to_db(forecasts, tuning_cutoff, best_params, company_id):
+    """
+    Compute and persist accuracy metrics for each SKU.
+
+    Uses the in-sample fitted values for the last tuning_cutoff_days of historical
+    data as the validation window. No extra training run is needed — the full-data
+    models already contain fitted values for all historical dates.
+
+    Saves one row per SKU + one aggregate row (item_id = NULL).
+    """
+    db: Session = SessionLocal()
+    try:
+        db.query(ModelMetrics).filter(ModelMetrics.company_id == company_id).delete()
+        db.commit()
+
+        records       = []
+        all_sku_stats = []
+        validation_start = pd.Timestamp(tuning_cutoff)
+
+        for sku, content in forecasts.items():
+            forecast = content['forecast']
+            df_full  = content['df_full']
+            df_train = content['df_train']
+
+            # Validation window: last N days of the historical data
+            df_val = df_full[df_full['ds'] > validation_start].copy()
+            if len(df_val) < 7:
+                continue
+
+            mae, rmse, mape, coverage_ic, bias = evaluate_full(forecast, df_val)
+            if mae is None:
+                continue
+
+            records.append(ModelMetrics(
+                company_id=company_id,
+                item_id=sku,
+                mae=round(mae, 4),
+                rmse=round(rmse, 4),
+                mape=round(mape, 2) if mape is not None else None,
+                coverage_ic=round(coverage_ic, 2),
+                bias=round(bias, 4),
+                training_samples=len(df_train),
+                validation_samples=len(df_val),
+                seasonality_mode=best_params.get('seasonality_mode', 'additive'),
+            ))
+            all_sku_stats.append({
+                'mae': mae, 'rmse': rmse, 'mape': mape,
+                'coverage_ic': coverage_ic, 'bias': bias,
+                'training_samples': len(df_train),
+                'validation_samples': len(df_val),
+            })
+
+        # Aggregate row (item_id = NULL)
+        if all_sku_stats:
+            valid_mapes = [s['mape'] for s in all_sku_stats if s['mape'] is not None]
+            records.append(ModelMetrics(
+                company_id=company_id,
+                item_id=None,
+                mae=round(float(np.mean([s['mae']  for s in all_sku_stats])), 4),
+                rmse=round(float(np.mean([s['rmse'] for s in all_sku_stats])), 4),
+                mape=round(float(np.mean(valid_mapes)), 2) if valid_mapes else None,
+                coverage_ic=round(float(np.mean([s['coverage_ic'] for s in all_sku_stats])), 2),
+                bias=round(float(np.mean([s['bias'] for s in all_sku_stats])), 4),
+                training_samples=sum(s['training_samples'] for s in all_sku_stats),
+                validation_samples=sum(s['validation_samples'] for s in all_sku_stats),
+                seasonality_mode=best_params.get('seasonality_mode', 'additive'),
+            ))
+
+        db.bulk_save_objects(records)
+        db.commit()
+        sku_count = len(records) - 1 if records else 0
+        print(f"Model metrics saved — {sku_count} SKUs + 1 aggregate row")
+
+    except Exception as e:
+        db.rollback()
+        print(f"Error saving model metrics: {e}")
+    finally:
+        db.close()
+
+
+# =============================================================================
 # Pipeline Entry Point (callable from FastAPI)
 # =============================================================================
 
@@ -484,6 +600,9 @@ def run_pipeline(df: pd.DataFrame, company_id: int = 1):
 
     # Save predictions to database
     save_predictions_to_db(forecasts, company_id=company_id)
+
+    # Compute and persist accuracy metrics (in-sample validation window)
+    save_model_metrics_to_db(forecasts, tuning_cutoff, best_params, company_id)
 
     print("\n── Pipeline completed ───────────────────────────────────────")
     print(f"  SKUs trained:              {len(forecasts)}")

--- a/frontend/src/app/predictions/page.tsx
+++ b/frontend/src/app/predictions/page.tsx
@@ -15,7 +15,7 @@ import {
 } from "recharts"
 import { format, parseISO } from "date-fns"
 import { es } from "date-fns/locale"
-import { Brain, TrendingUp, TrendingDown, Minus, Calendar, Package, BarChart3, ChevronRight, Layers, ScanBarcode } from "lucide-react"
+import { Brain, TrendingUp, TrendingDown, Minus, Calendar, Package, BarChart3, ChevronRight, Layers, ScanBarcode, HelpCircle, AlertTriangle, CheckCircle2, Info } from "lucide-react"
 import { DashboardLayout } from "@/components/dashboard-layout"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -44,12 +44,16 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog"
 import { Skeleton } from "@/components/ui/skeleton"
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card"
+import { cn } from "@/lib/utils"
 import {
   getSales,
   getPredictions,
   getPredictionsStatus,
+  getModelMetrics,
   type SaleRecord,
   type PredictionRecord,
+  type ModelMetricsResponse,
 } from "@/lib/api"
 
 // ─── types ────────────────────────────────────────────────────────────────────
@@ -220,6 +224,86 @@ function TrendIcon({ trend }: { trend: "up" | "down" | "flat" }) {
 }
 
 
+// ─── metrics modal helpers ────────────────────────────────────────────────────
+
+/** Returns color tier for a MAPE value — industry-agnostic thresholds. */
+function getMapeQuality(mape: number | null): {
+  label: string; textColor: string; bgColor: string; borderColor: string
+} {
+  if (mape === null) return { label: "Sin datos", textColor: "text-muted-foreground", bgColor: "bg-muted/50", borderColor: "border-border" }
+  if (mape < 15)    return { label: "Excelente",           textColor: "text-success",     bgColor: "bg-success/8",     borderColor: "border-success/30" }
+  if (mape < 30)    return { label: "Bueno",               textColor: "text-primary",     bgColor: "bg-primary/8",     borderColor: "border-primary/30" }
+  if (mape < 50)    return { label: "Moderado",            textColor: "text-warning",     bgColor: "bg-warning/8",     borderColor: "border-warning/30" }
+  return                   { label: "Alta incertidumbre",  textColor: "text-destructive", bgColor: "bg-destructive/8", borderColor: "border-destructive/30" }
+}
+
+function MetricCard({
+  label, value, tooltip, mape,
+}: {
+  label: string; value: string; tooltip: string; mape?: number | null
+}) {
+  const q = mape !== undefined ? getMapeQuality(mape) : null
+  return (
+    <HoverCard openDelay={200} closeDelay={100}>
+      <HoverCardTrigger asChild>
+        <div className={cn(
+          "rounded-lg border p-3 text-center cursor-help transition-colors",
+          q ? `${q.bgColor} ${q.borderColor}` : "border-border"
+        )}>
+          <p className="text-[11px] text-muted-foreground mb-1 flex items-center justify-center gap-1">
+            {label}
+            <HelpCircle className="h-3 w-3 shrink-0" />
+          </p>
+          <p className={cn("text-lg font-bold", q ? q.textColor : "text-foreground")}>{value}</p>
+          {q && mape !== null && (
+            <p className={cn("text-[10px] font-medium mt-0.5", q.textColor)}>{q.label}</p>
+          )}
+        </div>
+      </HoverCardTrigger>
+      <HoverCardContent align="center" className="w-72 text-xs leading-relaxed p-3">
+        {tooltip}
+      </HoverCardContent>
+    </HoverCard>
+  )
+}
+
+function ReliabilityBanner({ perSku }: { perSku: ModelMetricsResponse["per_sku"] }) {
+  if (perSku.length === 0) return null
+  const reliable = perSku.filter((s) => s.mape !== null && s.mape < 30).length
+  const total    = perSku.length
+  const pct      = Math.round((reliable / total) * 100)
+  const isHigh   = pct >= 80
+  const isMid    = pct >= 60
+
+  return (
+    <div className={cn(
+      "flex items-start gap-3 rounded-lg border px-4 py-3",
+      isHigh ? "bg-success/8 border-success/30" : isMid ? "bg-primary/8 border-primary/30" : "bg-warning/8 border-warning/30"
+    )}>
+      {isHigh
+        ? <CheckCircle2 className="h-4 w-4 shrink-0 text-success mt-0.5" />
+        : isMid
+        ? <Info className="h-4 w-4 shrink-0 text-primary mt-0.5" />
+        : <AlertTriangle className="h-4 w-4 shrink-0 text-warning mt-0.5" />
+      }
+      <div className="text-xs">
+        <p className={cn("font-semibold", isHigh ? "text-success" : isMid ? "text-primary" : "text-warning")}>
+          {isHigh ? "Alta fiabilidad" : isMid ? "Fiabilidad moderada" : "Fiabilidad baja"}
+          {" "}— {reliable} de {total} SKUs con MAPE &lt; 30%
+        </p>
+        <p className="text-muted-foreground mt-0.5">
+          {isHigh
+            ? "El modelo es confiable para la mayoría de productos. Adecuado para decisiones de inventario y compras."
+            : isMid
+            ? "Algunos SKUs tienen alta variabilidad. Revisa los productos con MAPE > 30% antes de usarlos en planificación crítica."
+            : "Varios SKUs tienen alta incertidumbre. Considera acumular más datos históricos o revisar la estacionalidad del negocio."
+          }
+        </p>
+      </div>
+    </div>
+  )
+}
+
 // ─── page ─────────────────────────────────────────────────────────────────────
 
 export default function PredictionsPage() {
@@ -232,6 +316,11 @@ export default function PredictionsPage() {
   const [granularity, setGranularity] = useState<Granularity>("daily")
   const [errorMsg, setErrorMsg] = useState("")
   const [refreshKey, setRefreshKey] = useState(0)
+
+  // Metrics dialog
+  const [metricsOpen, setMetricsOpen]       = useState(false)
+  const [metricsData, setMetricsData]       = useState<ModelMetricsResponse | null>(null)
+  const [metricsLoading, setMetricsLoading] = useState(false)
 
   // Re-load when the pipeline completes a new run
   useEffect(() => {
@@ -271,6 +360,23 @@ export default function PredictionsPage() {
       .then(setAllSales)
       .catch(() => setAllSales([]))
   }, [pageState, skus])
+
+  // Fetch metrics lazily when dialog opens (reset on new pipeline run)
+  useEffect(() => {
+    if (!metricsOpen || metricsData !== null) return
+    setMetricsLoading(true)
+    getModelMetrics()
+      .then(setMetricsData)
+      .catch(() => {})
+      .finally(() => setMetricsLoading(false))
+  }, [metricsOpen, metricsData])
+
+  // Reset cached metrics when a new pipeline run completes
+  useEffect(() => {
+    const handler = () => setMetricsData(null)
+    window.addEventListener("pipeline:dataready", handler)
+    return () => window.removeEventListener("pipeline:dataready", handler)
+  }, [])
 
   // Chart data — always show full 90-day forecast
   const chartData = useMemo((): ChartPoint[] => {
@@ -403,7 +509,7 @@ export default function PredictionsPage() {
             </div>
 
             {/* Model metrics dialog */}
-            <Dialog>
+            <Dialog open={metricsOpen} onOpenChange={setMetricsOpen}>
               <DialogTrigger asChild>
                 <Button variant="outline" className="gap-2">
                   <Brain className="h-4 w-4" />
@@ -417,75 +523,169 @@ export default function PredictionsPage() {
                     Métricas del Modelo Prophet
                   </DialogTitle>
                   <DialogDescription>
-                    Rendimiento del modelo en datos de validación y configuración de entrenamiento
+                    Rendimiento sobre el período de validación (últimos ~20% de datos históricos)
                   </DialogDescription>
                 </DialogHeader>
-                <div className="flex flex-col gap-6 pt-4">
-                  <div>
-                    <h4 className="text-sm font-semibold text-foreground mb-3">Métricas Generales</h4>
-                    <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
-                      {[
-                        { label: "MAE" },
-                        { label: "RMSE" },
-                        { label: "MAPE" },
-                        { label: "Cobertura IC" },
-                        { label: "Sesgo" },
-                      ].map(({ label }) => (
-                        <div key={label} className="rounded-lg border border-border p-3 text-center">
-                          <p className="text-xs text-muted-foreground">{label}</p>
-                          <p className="text-lg font-bold text-foreground">—</p>
-                        </div>
-                      ))}
+
+                {/* Loading skeleton */}
+                {metricsLoading && (
+                  <div className="flex flex-col gap-4 pt-4">
+                    <Skeleton className="h-14 rounded-lg" />
+                    <div className="grid grid-cols-5 gap-3">
+                      {Array.from({ length: 5 }).map((_, i) => <Skeleton key={i} className="h-20 rounded-lg" />)}
                     </div>
+                    <Skeleton className="h-24 rounded-lg" />
+                    <Skeleton className="h-48 rounded-lg" />
                   </div>
-                  <div>
-                    <h4 className="text-sm font-semibold text-foreground mb-3">Información de Entrenamiento</h4>
-                    <div className="rounded-lg border border-border p-4">
-                      <div className="grid grid-cols-2 gap-4 text-sm">
-                        {[
-                          "Último entrenamiento",
-                          "Muestras entrenamiento",
-                          "Muestras validación",
-                          "Changepoints detectados",
-                          "Estacionalidad",
-                          "Festivos",
-                        ].map((label) => (
-                          <div key={label}>
-                            <p className="text-muted-foreground">{label}</p>
-                            <p className="font-medium text-foreground">—</p>
-                          </div>
-                        ))}
+                )}
+
+                {/* No metrics yet */}
+                {!metricsLoading && !metricsData && (
+                  <div className="py-10 text-center text-sm text-muted-foreground">
+                    Las métricas se generan automáticamente al completar el entrenamiento del modelo.
+                    <br />Sube un archivo de ventas para activarlas.
+                  </div>
+                )}
+
+                {/* Metrics loaded */}
+                {!metricsLoading && metricsData && (
+                  <div className="flex flex-col gap-5 pt-4">
+
+                    {/* Reliability banner */}
+                    <ReliabilityBanner perSku={metricsData.per_sku} />
+
+                    {/* Aggregate metric cards */}
+                    <div>
+                      <h4 className="text-sm font-semibold text-foreground mb-3">Métricas Agregadas</h4>
+                      <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
+                        <MetricCard
+                          label="MAE"
+                          value={metricsData.aggregate?.mae != null ? metricsData.aggregate.mae.toFixed(2) : "—"}
+                          tooltip="Error Absoluto Medio en unidades/día. Si MAE = 5, el modelo se equivoca en promedio 5 unidades por día. No penaliza errores grandes más que pequeños. Útil para comunicar el error al negocio en términos concretos."
+                        />
+                        <MetricCard
+                          label="RMSE"
+                          value={metricsData.aggregate?.rmse != null ? metricsData.aggregate.rmse.toFixed(2) : "—"}
+                          tooltip="Raíz del Error Cuadrático Medio. Penaliza más los errores grandes. Si RMSE es notablemente mayor que MAE, hay días con errores muy altos — señal de que el modelo falla en picos de demanda."
+                        />
+                        <MetricCard
+                          label="MAPE"
+                          value={metricsData.aggregate?.mape != null ? `${metricsData.aggregate.mape.toFixed(1)}%` : "—"}
+                          mape={metricsData.aggregate?.mape ?? null}
+                          tooltip="Error Porcentual Absoluto Medio. El número más intuitivo: un MAPE del 20% significa que el modelo se equivoca ~20% arriba o abajo. Los umbrales varían por industria: <15% excelente, 15-30% bueno, 30-50% aceptable para productos volátiles o con pocos datos históricos."
+                        />
+                        <MetricCard
+                          label="Cobertura IC"
+                          value={metricsData.aggregate?.coverage_ic != null ? `${metricsData.aggregate.coverage_ic.toFixed(1)}%` : "—"}
+                          tooltip="Porcentaje de días reales que caen dentro del intervalo de confianza del modelo. Prophet usa un IC del 80% por defecto, por lo que ~80% es el valor esperado. Un valor muy inferior indica que el modelo subestima la incertidumbre."
+                        />
+                        <MetricCard
+                          label="Sesgo"
+                          value={metricsData.aggregate?.bias != null
+                            ? `${metricsData.aggregate.bias >= 0 ? "+" : ""}${metricsData.aggregate.bias.toFixed(2)}`
+                            : "—"}
+                          tooltip="Tendencia sistemática del modelo. Valor positivo significa que el modelo sobreestima la demanda en promedio; negativo que la subestima. Un sesgo cercano a 0 es ideal. Un sesgo positivo alto genera exceso de inventario; uno negativo, quiebres de stock."
+                        />
                       </div>
                     </div>
+
+                    {/* Training info */}
+                    {metricsData.aggregate && (
+                      <div>
+                        <h4 className="text-sm font-semibold text-foreground mb-3">Información de Entrenamiento</h4>
+                        <div className="rounded-lg border border-border bg-muted/20 p-4">
+                          <div className="grid grid-cols-2 gap-x-6 gap-y-3 text-sm sm:grid-cols-3">
+                            <div>
+                              <p className="text-xs text-muted-foreground">Último entrenamiento</p>
+                              <p className="font-medium text-foreground">
+                                {metricsData.aggregate.last_updated
+                                  ? new Date(metricsData.aggregate.last_updated).toLocaleString("es-CO", { day: "numeric", month: "short", year: "numeric", hour: "numeric", minute: "2-digit" })
+                                  : "—"}
+                              </p>
+                            </div>
+                            <div>
+                              <p className="text-xs text-muted-foreground">SKUs modelados</p>
+                              <p className="font-medium text-foreground">{metricsData.per_sku.length}</p>
+                            </div>
+                            <div>
+                              <p className="text-xs text-muted-foreground">Modo estacionalidad</p>
+                              <p className="font-medium text-foreground capitalize">{metricsData.aggregate.seasonality_mode ?? "—"}</p>
+                            </div>
+                            <div>
+                              <p className="text-xs text-muted-foreground">Muestras entrenamiento</p>
+                              <p className="font-medium text-foreground">{metricsData.aggregate.training_samples?.toLocaleString() ?? "—"}</p>
+                            </div>
+                            <div>
+                              <p className="text-xs text-muted-foreground">Muestras validación</p>
+                              <p className="font-medium text-foreground">{metricsData.aggregate.validation_samples?.toLocaleString() ?? "—"}</p>
+                            </div>
+                            <div>
+                              <p className="text-xs text-muted-foreground">Horizonte forecast</p>
+                              <p className="font-medium text-foreground">90 días</p>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    )}
+
+                    {/* Per-SKU table */}
+                    {metricsData.per_sku.length > 0 && (
+                      <div>
+                        <h4 className="text-sm font-semibold text-foreground mb-1">Métricas por SKU</h4>
+                        <p className="text-xs text-muted-foreground mb-3">Ordenado de mejor a peor MAPE. Haz hover sobre los encabezados para ver las definiciones.</p>
+                        <div className="rounded-md border border-border overflow-hidden">
+                          <Table>
+                            <TableHeader>
+                              <TableRow className="border-border hover:bg-transparent">
+                                <TableHead className="text-muted-foreground">SKU</TableHead>
+                                <TableHead className="text-muted-foreground text-right">MAE</TableHead>
+                                <TableHead className="text-muted-foreground text-right">RMSE</TableHead>
+                                <TableHead className="text-muted-foreground text-right">MAPE</TableHead>
+                                <TableHead className="text-muted-foreground text-right hidden sm:table-cell">Cobertura IC</TableHead>
+                                <TableHead className="text-muted-foreground text-center">Estado</TableHead>
+                              </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                              {metricsData.per_sku.map((sku) => {
+                                const q = getMapeQuality(sku.mape)
+                                return (
+                                  <TableRow key={sku.item_id} className="border-border">
+                                    <TableCell className="font-medium text-foreground text-sm">{sku.item_id}</TableCell>
+                                    <TableCell className="text-right font-mono text-sm text-foreground">
+                                      {sku.mae != null ? sku.mae.toFixed(2) : "—"}
+                                    </TableCell>
+                                    <TableCell className="text-right font-mono text-sm text-foreground">
+                                      {sku.rmse != null ? sku.rmse.toFixed(2) : "—"}
+                                    </TableCell>
+                                    <TableCell className="text-right">
+                                      <span className={cn("font-mono font-semibold text-sm", q.textColor)}>
+                                        {sku.mape != null ? `${sku.mape.toFixed(1)}%` : "—"}
+                                      </span>
+                                    </TableCell>
+                                    <TableCell className="text-right font-mono text-sm text-muted-foreground hidden sm:table-cell">
+                                      {sku.coverage_ic != null ? `${sku.coverage_ic.toFixed(1)}%` : "—"}
+                                    </TableCell>
+                                    <TableCell className="text-center">
+                                      <span className={cn("text-[10px] font-bold px-1.5 py-0.5 rounded-full", q.bgColor, q.borderColor, q.textColor, "border")}>
+                                        {q.label}
+                                      </span>
+                                    </TableCell>
+                                  </TableRow>
+                                )
+                              })}
+                            </TableBody>
+                          </Table>
+                        </div>
+                      </div>
+                    )}
+
+                    {/* Footnote */}
+                    <p className="text-[11px] text-muted-foreground leading-relaxed border-t border-border pt-3">
+                      ⚠ Estas métricas corresponden al <strong>ajuste sobre el período de validación</strong> (últimos ~20% de datos históricos). Al ser in-sample, pueden ser ligeramente optimistas. Para un análisis más riguroso, ejecuta validación cruzada temporal sobre el dataset completo.
+                    </p>
+
                   </div>
-                  <div>
-                    <h4 className="text-sm font-semibold text-foreground mb-3">Métricas por SKU</h4>
-                    <div className="rounded-md border border-border overflow-hidden">
-                      <Table>
-                        <TableHeader>
-                          <TableRow className="border-border hover:bg-transparent">
-                            <TableHead className="text-muted-foreground">SKU</TableHead>
-                            <TableHead className="text-muted-foreground text-right">MAE</TableHead>
-                            <TableHead className="text-muted-foreground text-right">RMSE</TableHead>
-                            <TableHead className="text-muted-foreground text-right">MAPE</TableHead>
-                            <TableHead className="text-muted-foreground text-right">Cobertura</TableHead>
-                          </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                          {skus.map((skuId) => (
-                            <TableRow key={skuId} className="border-border">
-                              <TableCell className="font-medium text-foreground text-sm">{skuId}</TableCell>
-                              <TableCell className="text-right font-mono text-foreground">—</TableCell>
-                              <TableCell className="text-right font-mono text-foreground">—</TableCell>
-                              <TableCell className="text-right font-mono text-foreground">—</TableCell>
-                              <TableCell className="text-right font-mono text-foreground">—</TableCell>
-                            </TableRow>
-                          ))}
-                        </TableBody>
-                      </Table>
-                    </div>
-                  </div>
-                </div>
+                )}
               </DialogContent>
             </Dialog>
           </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -155,6 +155,43 @@ export function getInventoryAlerts(): Promise<AlertsResponse> {
   return api.get<AlertsResponse>("/api/inventory/alerts").then((r) => r.data)
 }
 
+// ---------------------------------------------------------------------------
+// Model accuracy metrics (US-13)
+// ---------------------------------------------------------------------------
 
+export interface SkuMetrics {
+  item_id: string
+  mae: number | null
+  rmse: number | null
+  mape: number | null
+  coverage_ic: number | null
+  bias: number | null
+  training_samples: number | null
+  validation_samples: number | null
+  seasonality_mode: string | null
+  last_updated: string | null
+}
+
+export interface AggregateMetrics {
+  item_id: null
+  mae: number | null
+  rmse: number | null
+  mape: number | null
+  coverage_ic: number | null
+  bias: number | null
+  training_samples: number | null
+  validation_samples: number | null
+  seasonality_mode: string | null
+  last_updated: string | null
+}
+
+export interface ModelMetricsResponse {
+  aggregate: AggregateMetrics | null
+  per_sku: SkuMetrics[]
+}
+
+export function getModelMetrics(): Promise<ModelMetricsResponse> {
+  return api.get<ModelMetricsResponse>("/api/predictions/metrics").then((r) => r.data)
+}
 
 export default api


### PR DESCRIPTION
## Summary

- Adds `model_metrics` table to persist accuracy metrics after each Prophet training run
- Computes MAE, RMSE, MAPE, confidence interval coverage, and bias per SKU + aggregate
- New endpoint `GET /api/predictions/metrics` exposes metrics to the frontend
- Rewires the "Ver métricas del modelo" modal with real data, color-coded quality tiers, HoverCard explanations per metric, reliability banner, and per-SKU table

## What was built

**Backend**
- `ModelMetrics` ORM model — one row per SKU + one aggregate row (`item_id = NULL`)
- `evaluate_full()` in `prophet_demand_forecast.py` — computes all 5 metrics against the last ~20% of historical data (in-sample validation window, no extra training run)
- `save_model_metrics_to_db()` — called automatically at the end of `run_pipeline()`
- `GET /api/predictions/metrics` — returns aggregate + per-SKU metrics ordered by MAPE

**Frontend**
- Metrics fetched lazily when the dialog opens (no page-load cost)
- Reliability banner: "X de Y SKUs con MAPE < 30%" with color (green / blue / yellow)
- 5 aggregate metric cards with industry-agnostic color tiers and HoverCard guides
- Training info grid: last run, SKUs modeled, seasonality mode, sample counts
- Per-SKU table sorted best → worst MAPE with colored status badge per row
- Cache resets automatically when a new pipeline run completes (`pipeline:dataready`)

## Test plan

- [ ] Upload `reference_sales_2.csv` → wait for Prophet to finish
- [ ] Open "Ver métricas del modelo" → reliability banner and all 5 cards show real numbers
- [ ] Hover each metric card → HoverCard explanation appears
- [ ] Per-SKU table shows MAPE colored green/blue/yellow/red depending on value
- [ ] Re-upload sales file → modal resets and fetches fresh metrics on next open
- [ ] Endpoint `GET /api/predictions/metrics` returns 200 with aggregate + per_sku array

## Notes

Metrics are computed on the in-sample validation window (last ~20% of historical data per SKU). They are slightly optimistic compared to true out-of-sample evaluation. Full temporal cross-validation is available via Prophet's `cross_validation()` but adds significant training time — documented in `METRICAS_MODELO.md`.