### PR TITLE
fix: general fixes for US-15, US-20 and notification UX

### DIFF
--- a/backend/api/audit_logs.py
+++ b/backend/api/audit_logs.py
@@ -30,11 +30,11 @@ class ModelExecutionLogOut(BaseModel):
     id: int
     execution_date: datetime
     status: str
-    item_id: Optional[str]
-    mae: Optional[float]
-    rmse: Optional[float]
-    mape: Optional[float]
-    coverage: Optional[float]
+    skus_trained: Optional[int]
+    avg_mae: Optional[float]
+    avg_rmse: Optional[float]
+    avg_mape: Optional[float]
+    avg_coverage_ic: Optional[float]
     duration_seconds: Optional[float]
     error_message: Optional[str]
 
@@ -69,22 +69,22 @@ def log_upload(
 def log_model_execution(
     db: Session,
     status: str,
-    item_id: str = None,
-    mae: float = None,
-    rmse: float = None,
-    mape: float = None,
-    coverage: float = None,
+    skus_trained: int = None,
+    avg_mae: float = None,
+    avg_rmse: float = None,
+    avg_mape: float = None,
+    avg_coverage_ic: float = None,
     duration_seconds: float = None,
     error_message: str = None,
 ) -> ModelExecutionLog:
-    """Registra una ejecución del pipeline de Prophet."""
+    """Registra una ejecución completa del pipeline Prophet (una fila por run)."""
     entry = ModelExecutionLog(
         status=status,
-        item_id=item_id,
-        mae=mae,
-        rmse=rmse,
-        mape=mape,
-        coverage=coverage,
+        skus_trained=skus_trained,
+        avg_mae=avg_mae,
+        avg_rmse=avg_rmse,
+        avg_mape=avg_mape,
+        avg_coverage_ic=avg_coverage_ic,
         duration_seconds=duration_seconds,
         error_message=error_message,
     )

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -32,16 +32,12 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Oceanic Demand Forecast API", lifespan=lifespan)
 
-origins = [
-    "http://localhost:3000",
-    "http://127.0.0.1:3000",
-]
-
 app.add_middleware(
     CORSMiddleware,
     allow_origins=[
         "http://localhost:3000",
-        "http://52.205.157.189:3000"
+        "http://127.0.0.1:3000",
+        "http://52.205.157.189:3000",
     ],
     allow_credentials=True,
     allow_methods=["*"],

--- a/frontend/src/app/inventory/page.tsx
+++ b/frontend/src/app/inventory/page.tsx
@@ -272,26 +272,28 @@ function StatCard({
 }) {
   return (
     <div className="rounded-xl border bg-card p-5 shadow-sm">
-      <div className="flex items-center justify-between">
-        <p className="text-sm font-medium text-muted-foreground">{label}</p>
-        <div className={`flex h-9 w-9 items-center justify-center rounded-lg ${iconBg} ${iconColor}`}>
+      <div className="flex items-start justify-between">
+        <div className="flex flex-col gap-1">
+          <p className="text-sm font-medium text-muted-foreground">{label}</p>
+          <p
+            className={
+              highlight === "destructive"
+                ? "text-2xl font-bold text-destructive"
+                : highlight === "warning"
+                ? "text-2xl font-bold text-warning"
+                : highlight === "violet"
+                ? "text-2xl font-bold text-violet-500"
+                : "text-2xl font-bold tracking-tight text-card-foreground"
+            }
+          >
+            {value}
+          </p>
+          <p className="text-xs text-muted-foreground">{sub}</p>
+        </div>
+        <div className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-xl ${iconBg} ${iconColor}`}>
           {icon}
         </div>
       </div>
-      <p
-        className={
-          highlight === "destructive"
-            ? "mt-2 text-2xl font-bold text-destructive"
-            : highlight === "warning"
-            ? "mt-2 text-2xl font-bold text-warning"
-            : highlight === "violet"
-            ? "mt-2 text-2xl font-bold text-violet-500"
-            : "mt-2 text-2xl font-bold tracking-tight text-card-foreground"
-        }
-      >
-        {value}
-      </p>
-      <p className="mt-0.5 text-xs text-muted-foreground">{sub}</p>
     </div>
   )
 }

--- a/frontend/src/app/logs/page.tsx
+++ b/frontend/src/app/logs/page.tsx
@@ -27,11 +27,11 @@ interface ModelExecutionLog {
   id: number;
   execution_date: string;
   status: "success" | "failed";
-  item_id: string | null;
-  mae: number | null;
-  rmse: number | null;
-  mape: number | null;
-  coverage: number | null;
+  skus_trained: number | null;
+  avg_mae: number | null;
+  avg_rmse: number | null;
+  avg_mape: number | null;
+  avg_coverage_ic: number | null;
   duration_seconds: number | null;
   error_message: string | null;
 }
@@ -261,7 +261,7 @@ export default function LogsPage() {
               Ejecuciones del modelo Prophet
             </h2>
             <p className="text-xs text-slate-400 mt-0.5">
-              Una fila por SKU entrenado — métricas de accuracy del período de evaluación
+              Una fila por ejecución completa del pipeline — métricas agregadas de todos los SKUs entrenados
             </p>
           </div>
           {errorModel ? (
@@ -273,12 +273,12 @@ export default function LogsPage() {
                   <tr className="border-b border-slate-100 bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
                     <th className="px-4 py-3">#</th>
                     <th className="px-4 py-3">Fecha</th>
-                    <th className="px-4 py-3">SKU</th>
+                    <th className="px-4 py-3 text-right">SKUs</th>
                     <th className="px-4 py-3">Estado</th>
-                    <th className="px-4 py-3 text-right">MAE</th>
-                    <th className="px-4 py-3 text-right">RMSE</th>
-                    <th className="px-4 py-3 text-right">MAPE</th>
-                    <th className="px-4 py-3 text-right">Coverage</th>
+                    <th className="px-4 py-3 text-right">MAE prom.</th>
+                    <th className="px-4 py-3 text-right">RMSE prom.</th>
+                    <th className="px-4 py-3 text-right">MAPE prom.</th>
+                    <th className="px-4 py-3 text-right">Coverage prom.</th>
                     <th className="px-4 py-3 text-right">Duración (s)</th>
                     <th className="px-4 py-3">Error</th>
                   </tr>
@@ -305,24 +305,24 @@ export default function LogsPage() {
                         <td className="px-4 py-3 text-slate-500">
                           {fmt(log.execution_date)}
                         </td>
-                        <td className="px-4 py-3 font-mono text-xs text-slate-700">
-                          {log.item_id ?? "—"}
+                        <td className="px-4 py-3 text-right tabular-nums text-slate-700">
+                          {log.skus_trained ?? "—"}
                         </td>
                         <td className="px-4 py-3">
                           <StatusBadge status={log.status} />
                         </td>
                         <td className="px-4 py-3 text-right tabular-nums text-slate-700">
-                          {fmtNum(log.mae, 2)}
+                          {fmtNum(log.avg_mae, 2)}
                         </td>
                         <td className="px-4 py-3 text-right tabular-nums text-slate-700">
-                          {fmtNum(log.rmse, 2)}
+                          {fmtNum(log.avg_rmse, 2)}
                         </td>
                         <td className="px-4 py-3 text-right tabular-nums text-slate-700">
-                          {log.mape !== null ? `${(log.mape * 100).toFixed(1)}%` : "—"}
+                          {log.avg_mape !== null ? `${(log.avg_mape * 100).toFixed(1)}%` : "—"}
                         </td>
                         <td className="px-4 py-3 text-right tabular-nums text-slate-700">
-                          {log.coverage !== null
-                            ? `${(log.coverage * 100).toFixed(1)}%`
+                          {log.avg_coverage_ic !== null
+                            ? `${(log.avg_coverage_ic * 100).toFixed(1)}%`
                             : "—"}
                         </td>
                         <td className="px-4 py-3 text-right tabular-nums text-slate-500">

--- a/frontend/src/app/logs/page.tsx
+++ b/frontend/src/app/logs/page.tsx
@@ -9,7 +9,8 @@
  */
 
 import { useEffect, useState } from "react";
-import api from "@/lib/api"; // tu cliente Axios existente
+import api from "@/lib/api";
+import { DashboardLayout } from "@/components/dashboard-layout";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -126,14 +127,8 @@ export default function LogsPage() {
   }, []);
 
   return (
+    <DashboardLayout title="Audit Logs" subtitle="Historial de cargas de datos y ejecuciones del modelo de pronóstico.">
     <div className="min-h-screen bg-slate-50 px-6 py-8">
-      {/* Header */}
-      <div className="mb-8">
-        <h1 className="text-2xl font-bold text-slate-900">Audit Logs</h1>
-        <p className="mt-1 text-sm text-slate-500">
-          Historial de cargas de datos y ejecuciones del modelo de pronóstico.
-        </p>
-      </div>
 
       {/* Summary cards */}
       <div className="mb-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
@@ -318,11 +313,11 @@ export default function LogsPage() {
                           {fmtNum(log.avg_rmse, 2)}
                         </td>
                         <td className="px-4 py-3 text-right tabular-nums text-slate-700">
-                          {log.avg_mape !== null ? `${(log.avg_mape * 100).toFixed(1)}%` : "—"}
+                          {log.avg_mape !== null ? `${log.avg_mape.toFixed(1)}%` : "—"}
                         </td>
                         <td className="px-4 py-3 text-right tabular-nums text-slate-700">
                           {log.avg_coverage_ic !== null
-                            ? `${(log.avg_coverage_ic * 100).toFixed(1)}%`
+                            ? `${log.avg_coverage_ic.toFixed(1)}%`
                             : "—"}
                         </td>
                         <td className="px-4 py-3 text-right tabular-nums text-slate-500">
@@ -341,6 +336,7 @@ export default function LogsPage() {
         </div>
       )}
     </div>
+    </DashboardLayout>
   );
 }
 

--- a/frontend/src/app/logs/page.tsx
+++ b/frontend/src/app/logs/page.tsx
@@ -220,7 +220,7 @@ export default function LogsPage() {
                         className="border-b border-slate-50 transition-colors hover:bg-slate-50"
                       >
                         <td className="px-4 py-3 text-slate-400">{log.id}</td>
-                        <td className="max-w-[200px] truncate px-4 py-3 font-mono text-xs text-slate-700">
+                        <td className="max-w-[200px] truncate px-4 py-3 text-xs text-slate-700">
                           {log.filename}
                         </td>
                         <td className="px-4 py-3">

--- a/frontend/src/app/ventas-historicas/page.tsx
+++ b/frontend/src/app/ventas-historicas/page.tsx
@@ -89,23 +89,23 @@ function KpiCard({ title, value, delta, deltaType, sub, icon, iconBg, loading }:
   if (loading) {
     return (
       <Card>
-        <CardContent className="flex items-start justify-between pt-5">
+        <CardContent className="flex items-start justify-between">
           <div className="flex flex-col gap-2">
             <Skeleton className="h-3 w-28" />
-            <Skeleton className="h-8 w-24" />
+            <Skeleton className="h-7 w-24" />
             <Skeleton className="h-3 w-40" />
           </div>
-          <Skeleton className="h-11 w-11 rounded-xl" />
+          <Skeleton className="h-10 w-10 rounded-xl" />
         </CardContent>
       </Card>
     )
   }
   return (
     <Card>
-      <CardContent className="flex items-start justify-between pt-5">
+      <CardContent className="flex items-start justify-between">
         <div className="flex flex-col gap-1">
           <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{title}</span>
-          <span className="text-3xl font-bold tracking-tight tabular-nums text-foreground">{value}</span>
+          <span className="text-2xl font-bold tracking-tight tabular-nums text-foreground">{value}</span>
           {sub && <span className="text-xs text-muted-foreground">{sub}</span>}
           {delta && (
             <div className="flex items-center gap-1 mt-1">
@@ -124,7 +124,7 @@ function KpiCard({ title, value, delta, deltaType, sub, icon, iconBg, loading }:
             </div>
           )}
         </div>
-        <div className={cn("flex h-11 w-11 shrink-0 items-center justify-center rounded-xl", iconBg)}>
+        <div className={cn("flex h-10 w-10 shrink-0 items-center justify-center rounded-xl", iconBg)}>
           {icon}
         </div>
       </CardContent>
@@ -376,7 +376,7 @@ export default function VentasHistoricasPage() {
           />
         ) : topSku ? (
           <Card>
-            <CardContent className="flex items-start justify-between pt-5">
+            <CardContent className="flex items-start justify-between">
               <div className="flex flex-col gap-1">
                 <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
                   SKU Más Vendido
@@ -389,7 +389,7 @@ export default function VentasHistoricasPage() {
                   {topSku.pct.toFixed(1)}% del total
                 </span>
               </div>
-              <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-chart-3/10 text-chart-3">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-chart-3/10 text-chart-3">
                 <Star className="h-5 w-5" />
               </div>
             </CardContent>

--- a/frontend/src/app/ventas-historicas/page.tsx
+++ b/frontend/src/app/ventas-historicas/page.tsx
@@ -34,16 +34,12 @@ import { cn } from "@/lib/utils"
 import { format, parseISO, subMonths, startOfMonth, endOfMonth } from "date-fns"
 
 const PAGE_SIZE = 10
-const CHART_COLORS = [
-  "var(--chart-1)",
-  "var(--chart-2)",
-  "var(--chart-3)",
-  "var(--chart-4)",
-  "var(--chart-5)",
-  "oklch(0.50 0.04 250)",
-  "oklch(0.50 0.04 250)",
-  "oklch(0.50 0.04 250)",
-]
+function getBarColor(index: number, total: number): string {
+  const t = total <= 1 ? 0 : index / (total - 1)
+  const l = (0.42 + t * 0.28).toFixed(2)
+  const c = (0.16 - t * 0.08).toFixed(2)
+  return `oklch(${l} ${c} 250)`
+}
 
 const CAT_STYLES: Record<string, string> = {
   FOODS: "bg-emerald-50 text-emerald-700 border border-emerald-200",
@@ -385,7 +381,7 @@ export default function VentasHistoricasPage() {
                 <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
                   SKU Más Vendido
                 </span>
-                <span className="mt-1 font-mono text-lg font-bold tracking-tight text-foreground">
+                <span className="mt-1 text-lg font-bold tracking-tight text-foreground">
                   {topSku.id}
                 </span>
                 <span className="text-xs text-muted-foreground">
@@ -526,7 +522,7 @@ export default function VentasHistoricasPage() {
                   type="category"
                   dataKey="sku"
                   width={140}
-                  tick={{ fontSize: 11, fontFamily: "var(--font-mono)", fill: "var(--foreground)" }}
+                  tick={{ fontSize: 11, fill: "var(--foreground)" }}
                 />
                 <Tooltip
                   formatter={(v: number) => [v.toLocaleString("es-CO"), "Unidades"]}
@@ -540,7 +536,7 @@ export default function VentasHistoricasPage() {
                 />
                 <Bar dataKey="units" radius={[0, 4, 4, 0]} label={{ position: "right", fontSize: 11, formatter: (v: number) => v.toLocaleString() }}>
                   {chartData.map((_, i) => (
-                    <Cell key={i} fill={CHART_COLORS[Math.min(i, CHART_COLORS.length - 1)]} />
+                    <Cell key={i} fill={getBarColor(i, chartData.length)} />
                   ))}
                 </Bar>
               </BarChart>
@@ -622,7 +618,7 @@ export default function VentasHistoricasPage() {
                           {r.date}
                         </td>
                         <td className="px-4 py-3">
-                          <span className="font-mono text-xs font-medium text-foreground">
+                          <span className="text-xs font-medium text-foreground">
                             {r.item_id}
                           </span>
                         </td>

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -14,6 +14,7 @@ import {
   Activity,
   Package,
   TrendingUp,
+  ClipboardList,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useAuth } from "@/lib/auth-context"
@@ -25,6 +26,7 @@ const navItems = [
   { href: "/ventas-historicas", label: "Ventas Históricas", icon: TrendingUp },
   { href: "/inventory", label: "Inventario", icon: Package },
   { href: "/data-ingestion", label: "Ingesta de Datos", icon: Upload },
+  { href: "/logs", label: "Audit Logs", icon: ClipboardList },
 ]
 
 export function AppSidebar() {

--- a/frontend/src/components/dashboard-layout.tsx
+++ b/frontend/src/components/dashboard-layout.tsx
@@ -92,6 +92,7 @@ export function DashboardLayout({ children, title, subtitle, showLastRunAt }: Da
   const [toastVisible, setToastVisible] = useState(false)
   const [toastDismissed, setToastDismissed] = useState(false)
   const prevStatusRef = useRef<PredictionsStatus["status"]>("no_data")
+  const isInitialFetchRef = useRef(true)
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const autoDismissRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -102,8 +103,10 @@ export function DashboardLayout({ children, title, subtitle, showLastRunAt }: Da
   const [invToastDismissed, setInvToastDismissed] = useState(false)
   const invAutoDismissRef  = useRef<ReturnType<typeof setTimeout> | null>(null)
   const invProgressiveRef  = useRef<ReturnType<typeof setTimeout> | null>(null)
-  // Ref-mirror so fetchInventoryAlerts closure doesn't go stale
-  const invDismissedRef = useRef(false)
+  // Persisted across navigations via sessionStorage — resets only on new predictions
+  const invDismissedRef = useRef(
+    typeof window !== "undefined" && sessionStorage.getItem("oceanic-inv-alert-dismissed") === "1"
+  )
 
   const stopPolling = useCallback(() => {
     if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null }
@@ -122,9 +125,9 @@ export function DashboardLayout({ children, title, subtitle, showLastRunAt }: Da
 
       if (total > 0 && !invDismissedRef.current) {
         setInvToastVisible(true)
-        // Auto-dismiss after 15 s
+        // Auto-dismiss after 8 s
         if (invAutoDismissRef.current) clearTimeout(invAutoDismissRef.current)
-        invAutoDismissRef.current = setTimeout(() => setInvToastVisible(false), 15000)
+        invAutoDismissRef.current = setTimeout(() => setInvToastVisible(false), 8000)
       }
     } catch {
       // Silent — don't break layout if inventory endpoint is unavailable
@@ -140,9 +143,9 @@ export function DashboardLayout({ children, title, subtitle, showLastRunAt }: Da
       setPipelineStatus(next)
       if (data.last_run_at) setLastRunAt(data.last_run_at)
 
-      // Show toast on status transitions; also fires on initial load if already processing
+      // Show toast on real transitions; skip auto-show on initial mount if already processing
       if (prev !== next) {
-        if (next === "processing" || next === "uploaded") {
+        if ((next === "processing" || next === "uploaded") && !isInitialFetchRef.current) {
           setToastDismissed(false)
           setToastVisible(true)
         }
@@ -162,6 +165,8 @@ export function DashboardLayout({ children, title, subtitle, showLastRunAt }: Da
           stopPolling()
         }
       }
+
+      isInitialFetchRef.current = false
 
       // Start/stop polling based on status
       if ((next === "processing" || next === "uploaded") && !pollRef.current) {
@@ -194,18 +199,17 @@ export function DashboardLayout({ children, title, subtitle, showLastRunAt }: Da
     }
   }, [fetchInventoryAlerts])
 
-  // Re-fetch inventory alerts whenever pipeline finishes or data is refreshed
+  // Re-fetch inventory alerts when pipeline finishes with new predictions
   useEffect(() => {
     const handler = () => {
-      invDismissedRef.current = false   // new data → allow toast again
+      sessionStorage.removeItem("oceanic-inv-alert-dismissed")
+      invDismissedRef.current = false
       setInvToastDismissed(false)
       fetchInventoryAlerts()
     }
     window.addEventListener("pipeline:dataready", handler)
-    window.addEventListener("pipeline:refetch",   handler)
     return () => {
       window.removeEventListener("pipeline:dataready", handler)
-      window.removeEventListener("pipeline:refetch",   handler)
     }
   }, [fetchInventoryAlerts])
 
@@ -304,6 +308,7 @@ export function DashboardLayout({ children, title, subtitle, showLastRunAt }: Da
           setInvToastVisible(false)
           setInvToastDismissed(true)
           invDismissedRef.current = true
+          sessionStorage.setItem("oceanic-inv-alert-dismissed", "1")
         }}
       />
     </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,7 +1,7 @@
 import axios from "axios"
 
 const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL || 'http://52.205.157.189:8000' || "http://localhost:8000",
+  baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000",
 })
 
 export interface UploadResponse {


### PR DESCRIPTION
## What changed
- US-20: fixed type mismatch in audit logs schema, corrected MAPE/coverage display, added sidebar to logs page
- US-15: removed font-mono from labels, replaced static chart colors with blue gradient, resized KPI cards
- Inventory: fixed StatCard vertical alignment
- Notifications: inventory toast dismissal now persists across navigations via sessionStorage

## Related issues
Closes US-15, US-20