### PR TITLE
feat: add demand prediction alerts to dashboard (US-17)

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -937,6 +937,140 @@ async def get_inventory_alerts(db: Session = Depends(get_db)):
 
 
 # =============================================================================
+# GET /api/demand-alerts
+# =============================================================================
+
+DEMAND_WARNING_THRESHOLD  = 0.25  # 25 % — desviación moderada (atención)
+DEMAND_CRITICAL_THRESHOLD = 0.40  # 40 % — desviación significativa (crítico)
+
+
+@app.get(
+    "/api/demand-alerts",
+    tags=["Predictions"],
+    summary="Get demand deviation alerts per SKU",
+    description=(
+        "Compares the average predicted demand for the next 30 days against the average "
+        "historical sales for the last 30 days per SKU. "
+        f"Returns SKUs with deviation ≥{int(DEMAND_WARNING_THRESHOLD * 100)}% (warning) "
+        f"or ≥{int(DEMAND_CRITICAL_THRESHOLD * 100)}% (critical). "
+        "Direction is 'surge' when forecast > historical, 'drop' otherwise."
+    ),
+)
+async def get_demand_alerts(db: Session = Depends(get_db)):
+    """Return SKUs with significant demand deviation (forecast vs recent historical)."""
+    try:
+        from sqlalchemy import func as sqlfunc
+        from datetime import timedelta
+
+        company = db.query(Company).order_by(Company.id.asc()).first()
+        if not company:
+            return {"alerts": [], "message": "No hay datos disponibles."}
+
+        today = db.query(sqlfunc.max(SalesTransaction.date)).filter(
+            SalesTransaction.company_id == company.id
+        ).scalar()
+
+        if not today:
+            return {"alerts": [], "message": "No hay ventas históricas registradas."}
+
+        historical_start = today - timedelta(days=30)
+
+        # ------------------------------------------------------------------
+        # Average daily historical sales per SKU (last 30 days)
+        # ------------------------------------------------------------------
+        historical_rows = (
+            db.query(
+                SalesTransaction.item_id,
+                sqlfunc.avg(SalesTransaction.units_sold).label("avg_daily"),
+            )
+            .filter(
+                SalesTransaction.company_id == company.id,
+                SalesTransaction.date >= historical_start,
+                SalesTransaction.date <= today,
+            )
+            .group_by(SalesTransaction.item_id)
+            .all()
+        )
+
+        if not historical_rows:
+            return {"alerts": [], "message": "No hay ventas en los últimos 30 días."}
+
+        historical_avg: dict[str, float] = {
+            row.item_id: float(row.avg_daily) for row in historical_rows
+        }
+
+        # ------------------------------------------------------------------
+        # Average daily forecast per SKU (next 30 days from earliest forecast date)
+        # ------------------------------------------------------------------
+        forecast_start = db.query(sqlfunc.min(Prediction.forecast_date)).filter(
+            Prediction.company_id == company.id
+        ).scalar()
+
+        if not forecast_start:
+            return {"alerts": [], "message": "No hay pronóstico disponible. Sube datos de ventas primero."}
+
+        forecast_end = forecast_start + timedelta(days=30)
+
+        forecast_rows = (
+            db.query(
+                Prediction.item_id,
+                sqlfunc.avg(Prediction.predicted_demand).label("avg_daily"),
+            )
+            .filter(
+                Prediction.company_id == company.id,
+                Prediction.forecast_date >= forecast_start,
+                Prediction.forecast_date <= forecast_end,
+            )
+            .group_by(Prediction.item_id)
+            .all()
+        )
+
+        forecast_avg: dict[str, float] = {
+            row.item_id: float(row.avg_daily) for row in forecast_rows
+        }
+
+        # ------------------------------------------------------------------
+        # Build alerts — only SKUs that exceed the warning threshold
+        # ------------------------------------------------------------------
+        alerts = []
+        for item_id, hist_avg in historical_avg.items():
+            if hist_avg <= 0 or item_id not in forecast_avg:
+                continue
+
+            fore_avg = forecast_avg[item_id]
+            deviation = (fore_avg - hist_avg) / hist_avg
+            abs_deviation = abs(deviation)
+
+            if abs_deviation < DEMAND_WARNING_THRESHOLD:
+                continue
+
+            severity = "critical" if abs_deviation >= DEMAND_CRITICAL_THRESHOLD else "warning"
+
+            alerts.append({
+                "item_id": item_id,
+                "historical_avg": round(hist_avg, 2),
+                "forecast_avg": round(fore_avg, 2),
+                "deviation_pct": round(deviation * 100, 1),
+                "direction": "surge" if deviation > 0 else "drop",
+                "severity": severity,
+            })
+
+        alerts.sort(key=lambda x: abs(x["deviation_pct"]), reverse=True)
+
+        return {
+            "alerts": alerts,
+            "message": (
+                "Comparando pronóstico (próximos 30 días) vs ventas históricas (últimos 30 días). "
+                f"Atención ≥{int(DEMAND_WARNING_THRESHOLD * 100)}% · "
+                f"Crítico ≥{int(DEMAND_CRITICAL_THRESHOLD * 100)}%."
+            ),
+        }
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error calculating demand alerts: {e}")
+
+
+# =============================================================================
 # Helpers
 # =============================================================================
 

--- a/frontend/src/.gitignore
+++ b/frontend/src/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 .next/
 .env*.local
 .DS_Store
+*.tsbuildinfo

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { DashboardLayout } from "@/components/dashboard-layout"
 import { KpiCardsGrid } from "@/components/kpi-cards"
 import { SalesForecastChart, InventoryChart, CategoryDistributionChart } from "@/components/dashboard-charts"
 import { AlertsTable } from "@/components/alerts-table"
+import { DemandAlertsTable } from "@/components/demand-alerts-table"
 import { useAuth } from "@/lib/auth-context"
 export default function DashboardPage() {
   const { user } = useAuth()
@@ -25,12 +26,17 @@ export default function DashboardPage() {
         <InventoryChart />
       </section>
 
+      {/* Alerts Row — stockout alerts + demand alerts lado a lado */}
+      <section aria-label="Alertas" className="mb-8 grid gap-6 lg:grid-cols-2">
+        <AlertsTable />
+        <DemandAlertsTable />
+      </section>
+
       {/* Bottom Row */}
       <section aria-label="Detalle" className="grid gap-6 lg:grid-cols-3">
-        <div className="lg:col-span-2">
-          <AlertsTable />
+        <div className="lg:col-span-3">
+          <CategoryDistributionChart />
         </div>
-        <CategoryDistributionChart />
       </section>
     </DashboardLayout>
   )

--- a/frontend/src/components/alerts-table.tsx
+++ b/frontend/src/components/alerts-table.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
-import { AlertTriangle, TrendingDown, BarChart2, History, ShoppingCart, HelpCircle } from "lucide-react"
+import { AlertTriangle, TrendingDown, BarChart2, History, ShoppingCart, HelpCircle, ChevronDown, ChevronUp } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { getInventoryAlerts, type StockoutAlert, type AlertMode } from "@/lib/api"
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card"
@@ -194,6 +194,7 @@ export function AlertsTable() {
   const [modeMessage, setModeMessage] = useState("")
   const [loading, setLoading]     = useState(true)
   const [refreshKey, setRefreshKey] = useState(0)
+  const [expanded, setExpanded]   = useState(false)
 
   useEffect(() => {
     const handler = () => setRefreshKey((k) => k + 1)
@@ -207,6 +208,7 @@ export function AlertsTable() {
 
   useEffect(() => {
     setLoading(true)
+    setExpanded(false)
     getInventoryAlerts()
       .then((res) => {
         setAlerts(res.alerts)
@@ -220,6 +222,9 @@ export function AlertsTable() {
       .finally(() => setLoading(false))
   }, [refreshKey])
 
+  const VISIBLE_LIMIT = 3
+  const visibleAlerts = expanded ? alerts : alerts.slice(0, VISIBLE_LIMIT)
+  const hiddenCount   = alerts.length - VISIBLE_LIMIT
   const criticalCount = alerts.filter((a) => a.stock_status === "critical").length
 
   return (
@@ -271,12 +276,24 @@ export function AlertsTable() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {alerts.map((alert) => (
+                  {visibleAlerts.map((alert) => (
                     <AlertRow key={`${alert.item_id}-${alert.store_id}`} alert={alert} />
                   ))}
                 </TableBody>
               </Table>
             </div>
+            {hiddenCount > 0 && (
+              <button
+                onClick={() => setExpanded((e) => !e)}
+                className="mt-3 flex w-full items-center justify-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors py-1"
+              >
+                {expanded ? (
+                  <>Ver menos <ChevronUp className="h-3 w-3" /></>
+                ) : (
+                  <>Ver {hiddenCount} más <ChevronDown className="h-3 w-3" /></>
+                )}
+              </button>
+            )}
           </>
         )}
       </CardContent>

--- a/frontend/src/components/dashboard-layout.tsx
+++ b/frontend/src/components/dashboard-layout.tsx
@@ -6,7 +6,7 @@ import { useEffect, useRef, useState, useCallback, type ReactNode } from "react"
 import { AppSidebar } from "@/components/app-sidebar"
 import { NotificationBell } from "@/components/notification-bell"
 import { PipelineToast } from "@/components/pipeline-toast"
-import { getPredictionsStatus, getInventoryAlerts, type PredictionsStatus } from "@/lib/api"
+import { getPredictionsStatus, getInventoryAlerts, getDemandAlerts, type PredictionsStatus } from "@/lib/api"
 import { AlertTriangle, X } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { cn } from "@/lib/utils"
@@ -108,6 +108,8 @@ export function DashboardLayout({ children, title, subtitle, showLastRunAt }: Da
     typeof window !== "undefined" && sessionStorage.getItem("oceanic-inv-alert-dismissed") === "1"
   )
 
+  const [demandAlertCount, setDemandAlertCount] = useState(0)
+
   const stopPolling = useCallback(() => {
     if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null }
   }, [])
@@ -131,6 +133,15 @@ export function DashboardLayout({ children, title, subtitle, showLastRunAt }: Da
       }
     } catch {
       // Silent — don't break layout if inventory endpoint is unavailable
+    }
+  }, [])
+
+  const fetchDemandAlerts = useCallback(async () => {
+    try {
+      const data = await getDemandAlerts()
+      setDemandAlertCount(data.alerts.length)
+    } catch {
+      // Silent — no romper el layout si el endpoint no está disponible
     }
   }, [])
 
@@ -191,13 +202,16 @@ export function DashboardLayout({ children, title, subtitle, showLastRunAt }: Da
   // Initial fetch on mount — inventory alerts
   // 150ms delay so the first render paints before the toast slides in
   useEffect(() => {
-    const t = setTimeout(fetchInventoryAlerts, 150)
+    const t = setTimeout(() => {
+      fetchInventoryAlerts()
+      fetchDemandAlerts()
+    }, 150)
     return () => {
       clearTimeout(t)
       if (invAutoDismissRef.current) clearTimeout(invAutoDismissRef.current)
       if (invProgressiveRef.current)  clearTimeout(invProgressiveRef.current)
     }
-  }, [fetchInventoryAlerts])
+  }, [fetchInventoryAlerts, fetchDemandAlerts])
 
   // Re-fetch inventory alerts when pipeline finishes with new predictions
   useEffect(() => {
@@ -206,12 +220,15 @@ export function DashboardLayout({ children, title, subtitle, showLastRunAt }: Da
       invDismissedRef.current = false
       setInvToastDismissed(false)
       fetchInventoryAlerts()
+      fetchDemandAlerts()
     }
     window.addEventListener("pipeline:dataready", handler)
+    window.addEventListener("pipeline:refetch", handler)
     return () => {
       window.removeEventListener("pipeline:dataready", handler)
+      window.removeEventListener("pipeline:refetch", handler)
     }
-  }, [fetchInventoryAlerts])
+  }, [fetchInventoryAlerts, fetchDemandAlerts])
 
   // Listen for trigger from data-ingestion page after upload — pipeline
   useEffect(() => {
@@ -270,6 +287,7 @@ export function DashboardLayout({ children, title, subtitle, showLastRunAt }: Da
                   toastDismissed
                 }
                 inventoryAlertCount={invAlertTotal}
+                demandAlertCount={demandAlertCount}
                 onClick={() => {
                   // Bell click → re-show inventory alert toast (primary) …
                   if (invAlertTotal > 0) {

--- a/frontend/src/components/demand-alerts-table.tsx
+++ b/frontend/src/components/demand-alerts-table.tsx
@@ -1,0 +1,264 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { TrendingUp, TrendingDown, Activity, ChevronDown, ChevronUp, HelpCircle } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { getDemandAlerts, type DemandAlert } from "@/lib/api"
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card"
+
+// ---------------------------------------------------------------------------
+// Guía informativa
+// ---------------------------------------------------------------------------
+
+function GuideRow({ dot, label, desc }: { dot: string; label: string; desc: string }) {
+  return (
+    <div className="flex items-start gap-2">
+      <span className={`mt-0.5 inline-block h-2 w-2 shrink-0 rounded-full ${dot}`} />
+      <div className="min-w-0">
+        <span className="font-medium text-foreground">{label}</span>
+        <span className="text-muted-foreground"> — {desc}</span>
+      </div>
+    </div>
+  )
+}
+
+function ColRow({ label, desc }: { label: string; desc: string }) {
+  return (
+    <div className="flex gap-2">
+      <span className="w-32 shrink-0 font-medium text-foreground">{label}</span>
+      <span className="text-muted-foreground">{desc}</span>
+    </div>
+  )
+}
+
+function DemandAlertsGuide() {
+  return (
+    <HoverCard openDelay={200} closeDelay={100}>
+      <HoverCardTrigger asChild>
+        <button
+          className="flex h-5 w-5 items-center justify-center rounded-full text-muted-foreground hover:text-foreground transition-colors"
+          aria-label="Cómo interpretar las alertas de demanda"
+        >
+          <HelpCircle className="h-4 w-4" />
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent align="start" className="w-96 p-4 text-xs space-y-4">
+        <p className="text-sm font-semibold text-foreground">Cómo leer las alertas de demanda</p>
+
+        <div className="rounded-md bg-muted/60 px-3 py-2">
+          <p className="text-muted-foreground leading-relaxed">
+            Compara el <span className="font-medium text-foreground">promedio diario pronosticado</span> (próximos 30 días)
+            contra las <span className="font-medium text-foreground">ventas históricas recientes</span> (últimos 30 días).
+            Una desviación grande indica que la demanda se está alejando del comportamiento habitual del SKU.
+          </p>
+        </div>
+
+        <div className="space-y-1.5">
+          <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">Severidad</p>
+          <GuideRow dot="bg-destructive" label="Crítico"  desc="Desviación ≥40% respecto al histórico reciente. Requiere atención inmediata." />
+          <GuideRow dot="bg-warning"     label="Atención" desc="Desviación ≥25%. Monitorear y planificar con anticipación." />
+        </div>
+
+        <div className="space-y-1.5">
+          <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">Dirección</p>
+          <GuideRow dot="bg-blue-400" label="Alza"  desc="El pronóstico supera las ventas recientes. Considera aumentar el stock." />
+          <GuideRow dot="bg-slate-400" label="Caída" desc="El pronóstico está por debajo del histórico. Revisa si hay sobrestock." />
+        </div>
+
+        <div className="space-y-1.5">
+          <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">Columnas</p>
+          <ColRow label="Desviación"          desc="Diferencia porcentual entre pronóstico e histórico. Positivo = alza, negativo = caída." />
+          <ColRow label="Histórico → Pron."   desc="Promedio diario vendido en los últimos 30 días vs el pronosticado para los próximos 30." />
+        </div>
+      </HoverCardContent>
+    </HoverCard>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Helpers de estilo por severidad
+// ---------------------------------------------------------------------------
+
+function rowStyle(severity: DemandAlert["severity"]) {
+  return severity === "critical"
+    ? "border-l-2 border-l-destructive bg-destructive/5 hover:bg-destructive/10"
+    : "border-l-2 border-l-warning bg-warning/5 hover:bg-warning/10"
+}
+
+function badgeStyle(severity: DemandAlert["severity"]) {
+  return severity === "critical"
+    ? "bg-destructive/15 text-destructive"
+    : "bg-warning/15 text-warning"
+}
+
+function deviationStyle(severity: DemandAlert["severity"]) {
+  return severity === "critical" ? "text-destructive" : "text-warning"
+}
+
+function severityLabel(severity: DemandAlert["severity"]) {
+  return severity === "critical" ? "Crítico" : "Atención"
+}
+
+// ---------------------------------------------------------------------------
+// Fila individual
+// ---------------------------------------------------------------------------
+
+function DemandAlertRow({ alert }: { alert: DemandAlert }) {
+  const isSurge = alert.direction === "surge"
+
+  return (
+    <TableRow className={cn("transition-colors", rowStyle(alert.severity))}>
+      <TableCell>
+        <div className="flex flex-col gap-1">
+          <Badge variant="secondary" className={cn("gap-1 w-fit", badgeStyle(alert.severity))}>
+            {isSurge ? <TrendingUp className="h-3 w-3" /> : <TrendingDown className="h-3 w-3" />}
+            {severityLabel(alert.severity)}
+          </Badge>
+          <span className="text-[10px] text-muted-foreground pl-0.5">
+            {isSurge ? "Alza" : "Caída"}
+          </span>
+        </div>
+      </TableCell>
+
+      <TableCell className="font-medium text-card-foreground">
+        {alert.item_id}
+      </TableCell>
+
+      <TableCell>
+        <span className={cn("font-semibold", deviationStyle(alert.severity))}>
+          {isSurge ? "+" : ""}{alert.deviation_pct}%
+        </span>
+      </TableCell>
+
+      <TableCell className="hidden md:table-cell text-muted-foreground text-sm">
+        <span>{alert.historical_avg.toFixed(1)} uds/día</span>
+        <span className="mx-1.5 text-muted-foreground/50">→</span>
+        <span className="font-medium text-card-foreground">{alert.forecast_avg.toFixed(1)} uds/día</span>
+      </TableCell>
+    </TableRow>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Componente principal
+// ---------------------------------------------------------------------------
+
+/** Tabla de alertas de desviación de demanda predicha vs histórica (US-17). */
+export function DemandAlertsTable() {
+  const [alerts, setAlerts]         = useState<DemandAlert[]>([])
+  const [message, setMessage]       = useState("")
+  const [loading, setLoading]       = useState(true)
+  const [refreshKey, setRefreshKey] = useState(0)
+  const [expanded, setExpanded]     = useState(false)
+
+  useEffect(() => {
+    const handler = () => setRefreshKey((k) => k + 1)
+    window.addEventListener("pipeline:dataready", handler)
+    window.addEventListener("pipeline:refetch", handler)
+    return () => {
+      window.removeEventListener("pipeline:dataready", handler)
+      window.removeEventListener("pipeline:refetch", handler)
+    }
+  }, [])
+
+  useEffect(() => {
+    setLoading(true)
+    setExpanded(false)
+    getDemandAlerts()
+      .then((res) => {
+        setAlerts(res.alerts)
+        setMessage(res.message)
+      })
+      .catch(() => setAlerts([]))
+      .finally(() => setLoading(false))
+  }, [refreshKey])
+
+  const VISIBLE_LIMIT = 3
+  const visibleAlerts = expanded ? alerts : alerts.slice(0, VISIBLE_LIMIT)
+  const hiddenCount   = alerts.length - VISIBLE_LIMIT
+  const criticalCount = alerts.filter((a) => a.severity === "critical").length
+  const warningCount  = alerts.filter((a) => a.severity === "warning").length
+
+  return (
+    <Card className="bg-card">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-card-foreground">
+          <Activity className="h-5 w-5 text-warning" />
+          Alertas de Demanda
+          <DemandAlertsGuide />
+          {alerts.length > 0 && (
+            <Badge variant="secondary" className="ml-auto bg-warning/10 text-warning">
+              {alerts.length} activas
+            </Badge>
+          )}
+        </CardTitle>
+        {criticalCount > 0 && (
+          <CardDescription className="text-destructive font-medium">
+            {criticalCount} SKU{criticalCount > 1 ? "s" : ""} con desviación crítica ≥40%
+          </CardDescription>
+        )}
+        {criticalCount === 0 && warningCount > 0 && (
+          <CardDescription>
+            {warningCount} SKU{warningCount > 1 ? "s" : ""} con desviación moderada ≥25%
+          </CardDescription>
+        )}
+      </CardHeader>
+
+      <CardContent>
+        {loading ? (
+          <div className="flex flex-col gap-3">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-12 w-full rounded-lg" />
+            ))}
+          </div>
+        ) : alerts.length === 0 ? (
+          <div className="py-8 text-center">
+            <Activity className="mx-auto h-8 w-8 text-muted-foreground/40 mb-2" />
+            <p className="text-sm text-muted-foreground">
+              {message || "Sin alertas — la demanda proyectada es consistente con el histórico reciente."}
+            </p>
+          </div>
+        ) : (
+          <>
+            {message && (
+              <p className="text-xs text-muted-foreground mb-3">{message}</p>
+            )}
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow className="text-xs uppercase tracking-wide">
+                    <TableHead>Tipo</TableHead>
+                    <TableHead>SKU</TableHead>
+                    <TableHead>Desviación</TableHead>
+                    <TableHead className="hidden md:table-cell">Histórico → Pronóstico</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {visibleAlerts.map((alert) => (
+                    <DemandAlertRow key={alert.item_id} alert={alert} />
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+            {hiddenCount > 0 && (
+              <button
+                onClick={() => setExpanded((e) => !e)}
+                className="mt-3 flex w-full items-center justify-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors py-1"
+              >
+                {expanded ? (
+                  <>Ver menos <ChevronUp className="h-3 w-3" /></>
+                ) : (
+                  <>Ver {hiddenCount} más <ChevronDown className="h-3 w-3" /></>
+                )}
+              </button>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/notification-bell.tsx
+++ b/frontend/src/components/notification-bell.tsx
@@ -7,11 +7,14 @@ interface NotificationBellProps {
   hasActiveNotification: boolean
   /** Shows a numeric badge for inventory stockout alerts */
   inventoryAlertCount?: number
+  /** Shows additional count for demand deviation alerts */
+  demandAlertCount?: number
   onClick: () => void
 }
 
-export function NotificationBell({ hasActiveNotification, inventoryAlertCount = 0, onClick }: NotificationBellProps) {
-  const showCount  = inventoryAlertCount > 0
+export function NotificationBell({ hasActiveNotification, inventoryAlertCount = 0, demandAlertCount = 0, onClick }: NotificationBellProps) {
+  const totalCount = inventoryAlertCount + demandAlertCount
+  const showCount  = totalCount > 0
   const showDot    = !showCount && hasActiveNotification
 
   return (
@@ -22,10 +25,10 @@ export function NotificationBell({ hasActiveNotification, inventoryAlertCount = 
     >
       <Bell className="h-4 w-4" />
 
-      {/* Numeric badge — inventory stockout alerts */}
+      {/* Numeric badge — combined inventory + demand alerts */}
       {showCount && (
         <span className="absolute -top-0.5 -right-0.5 flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-destructive px-1 text-[9px] font-bold leading-none text-white">
-          {inventoryAlertCount > 9 ? "9+" : inventoryAlertCount}
+          {totalCount > 9 ? "9+" : totalCount}
         </span>
       )}
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -194,4 +194,26 @@ export function getModelMetrics(): Promise<ModelMetricsResponse> {
   return api.get<ModelMetricsResponse>("/api/predictions/metrics").then((r) => r.data)
 }
 
+// ---------------------------------------------------------------------------
+// Demand deviation alerts (US-17)
+// ---------------------------------------------------------------------------
+
+export interface DemandAlert {
+  item_id: string
+  historical_avg: number
+  forecast_avg: number
+  deviation_pct: number
+  direction: "surge" | "drop"
+  severity: "warning" | "critical"
+}
+
+export interface DemandAlertsResponse {
+  alerts: DemandAlert[]
+  message: string
+}
+
+export function getDemandAlerts(): Promise<DemandAlertsResponse> {
+  return api.get<DemandAlertsResponse>("/api/demand-alerts").then((r) => r.data)
+}
+
 export default api


### PR DESCRIPTION
## What changed
Implements US-17: demand deviation alerts that compare predicted demand against recent historical sales, displayed on the dashboard alongside existing stockout alerts.

**Backend**
- New `GET /api/demand-alerts` endpoint: compares the average daily forecast (next 30 days) against average historical sales (last 30 days) per SKU. Returns alerts with
severity `warning` (≥25%) or `critical` (≥40%), sorted by absolute deviation descending.

**Frontend**
- New `DemandAlertsTable` component with loading/empty/data states, pagination (3 visible + expand), info popover, and automatic refresh on pipeline events.
- `AlertsTable` updated with the same pagination pattern (3 + expand).
- Dashboard reorganized: both alert tables side by side in a 2-column row; `CategoryDistributionChart` moved to its own full-width row below.
- `NotificationBell` now shows a combined count of inventory and demand alerts.
- `DashboardLayout` fetches demand alerts on mount and on `pipeline:dataready` events.

## Related issue
Closes US-17