### PR TITLE
chore: add automated tests for Sprint 3 user stories (US-15, 17, 18, 19, 20)

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -22,9 +22,11 @@ from database.models import (  # noqa: E402
     DataSource,
     InventoryAnalysis,
     InventorySnapshot,
+    ModelExecutionLog,
     ModelMetrics,
     Prediction,
     SalesTransaction,
+    UploadLog,
 )
 
 
@@ -49,6 +51,8 @@ def engine():
 
 def _truncate_all(session) -> None:
     """Delete all rows in FK-safe order."""
+    session.query(ModelExecutionLog).delete()
+    session.query(UploadLog).delete()
     session.query(ModelMetrics).delete()
     session.query(InventoryAnalysis).delete()
     session.query(InventorySnapshot).delete()

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -7,6 +7,9 @@ spinning up a real server. Covers:
   - US-11: GET /api/inventory/alerts
   - US-12: GET /api/predictions/status
   - US-13: GET /api/predictions/metrics
+  - US-15: GET /api/sales, GET /api/sales/range
+  - US-17: GET /api/demand-alerts
+  - US-20: GET /api/logs/uploads, GET /api/logs/model-executions
 """
 
 import pytest
@@ -16,8 +19,11 @@ from database.models import (
     Company,
     DataSource,
     InventorySnapshot,
+    ModelExecutionLog,
     ModelMetrics,
     Prediction,
+    SalesTransaction,
+    UploadLog,
 )
 
 
@@ -231,3 +237,230 @@ def test_get_metrics_returns_aggregate_and_per_sku(client, db):
     assert float(data["aggregate"]["mae"]) == pytest.approx(2.5, rel=0.01)
     assert len(data["per_sku"]) == 1
     assert data["per_sku"][0]["item_id"] == "SKU-X"
+
+
+# ---------------------------------------------------------------------------
+# US-15 — Sales View
+# ---------------------------------------------------------------------------
+
+def test_get_sales_returns_rows_when_data_exists(client, db):
+    """Happy path: sales data in DB → rows returned with correct item_id and units_sold."""
+    company = _seed_company(db)
+    db.add(SalesTransaction(
+        company_id=company.id,
+        item_id="FOODS_001",
+        date=date(2017, 1, 1),
+        units_sold=10,
+        sell_price=5.0,
+    ))
+    db.commit()
+
+    response = client.get("/api/sales")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["item_id"] == "FOODS_001"
+    assert data[0]["units_sold"] == 10
+
+
+def test_get_sales_no_data_returns_empty_list(client):
+    """Alt path: no sales in DB → endpoint returns empty list, not 404."""
+    response = client.get("/api/sales")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_get_sales_filters_by_item_id(client, db):
+    """Happy path: item_id query param → only matching rows are returned."""
+    company = _seed_company(db)
+    for item in ["FOODS_001", "HOBBIES_001"]:
+        db.add(SalesTransaction(
+            company_id=company.id,
+            item_id=item,
+            date=date(2017, 1, 1),
+            units_sold=5,
+            sell_price=2.0,
+        ))
+    db.commit()
+
+    response = client.get("/api/sales", params={"item_id": "FOODS_001"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["item_id"] == "FOODS_001"
+
+
+def test_get_sales_range_returns_min_max_dates(client, db):
+    """Happy path: sales data exists → min_date and max_date match seeded data."""
+    company = _seed_company(db)
+    for d_val in [date(2017, 1, 1), date(2017, 6, 30)]:
+        db.add(SalesTransaction(
+            company_id=company.id,
+            item_id="SKU-X",
+            date=d_val,
+            units_sold=1,
+            sell_price=1.0,
+        ))
+    db.commit()
+
+    response = client.get("/api/sales/range")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["min_date"] == "2017-01-01"
+    assert data["max_date"] == "2017-06-30"
+
+
+def test_get_sales_range_no_data_returns_404(client):
+    """Alt path: no sales data in DB → /api/sales/range returns 404."""
+    response = client.get("/api/sales/range")
+
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# US-17 — Demand Prediction Alerts
+# ---------------------------------------------------------------------------
+
+def test_get_demand_alerts_no_sales_returns_empty(client):
+    """Alt path: no sales data → alerts list is empty regardless of forecast."""
+    response = client.get("/api/demand-alerts")
+
+    assert response.status_code == 200
+    assert response.json()["alerts"] == []
+
+
+def test_get_demand_alerts_critical_sku_appears(client, db):
+    """Happy path: SKU whose 30-day forecast avg is 50% above its 30-day
+    historical avg appears with severity='critical' and direction='surge'."""
+    company = _seed_company(db)
+
+    # 31 days of historical sales at 2 units/day
+    for i in range(31):
+        db.add(SalesTransaction(
+            company_id=company.id,
+            item_id="SURGE-001",
+            date=date(2017, 1, 1) + timedelta(days=i),
+            units_sold=2,
+            sell_price=5.0,
+        ))
+
+    # 30 days of forecast at 3 units/day → 50% above historical
+    for i in range(30):
+        db.add(Prediction(
+            company_id=company.id,
+            item_id="SURGE-001",
+            forecast_date=date(2017, 2, 1) + timedelta(days=i),
+            predicted_demand=3.0,
+            yhat_lower=2.5,
+            yhat_upper=3.5,
+        ))
+    db.commit()
+
+    response = client.get("/api/demand-alerts")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["alerts"]) >= 1
+    alert = next(a for a in data["alerts"] if a["item_id"] == "SURGE-001")
+    assert alert["severity"] == "critical"
+    assert alert["direction"] == "surge"
+    assert float(alert["deviation_pct"]) == pytest.approx(50.0, rel=0.05)
+
+
+def test_get_demand_alerts_low_deviation_sku_excluded(client, db):
+    """Alt path: deviation < 25% threshold → SKU does not appear in alerts."""
+    company = _seed_company(db)
+
+    # historical avg = 2, forecast avg = 2.1 → 5% deviation → below threshold
+    for i in range(31):
+        db.add(SalesTransaction(
+            company_id=company.id,
+            item_id="STABLE-001",
+            date=date(2017, 1, 1) + timedelta(days=i),
+            units_sold=2,
+            sell_price=5.0,
+        ))
+    for i in range(30):
+        db.add(Prediction(
+            company_id=company.id,
+            item_id="STABLE-001",
+            forecast_date=date(2017, 2, 1) + timedelta(days=i),
+            predicted_demand=2.1,
+            yhat_lower=1.9,
+            yhat_upper=2.3,
+        ))
+    db.commit()
+
+    response = client.get("/api/demand-alerts")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert all(a["item_id"] != "STABLE-001" for a in data["alerts"])
+
+
+# ---------------------------------------------------------------------------
+# US-20 — Audit Logs
+# ---------------------------------------------------------------------------
+
+def test_get_upload_logs_empty_when_no_records(client):
+    """Alt path: no upload logs in DB → endpoint returns empty list."""
+    response = client.get("/api/logs/uploads")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_get_upload_logs_returns_recorded_entries(client, db):
+    """Happy path: upload log seeded in DB → returned with correct fields."""
+    db.add(UploadLog(
+        filename="sales_2017.csv",
+        file_type="sales",
+        status="success",
+        records_processed=42,
+    ))
+    db.commit()
+
+    response = client.get("/api/logs/uploads")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["filename"] == "sales_2017.csv"
+    assert data[0]["file_type"] == "sales"
+    assert data[0]["status"] == "success"
+    assert data[0]["records_processed"] == 42
+
+
+def test_get_model_execution_logs_empty_when_no_records(client):
+    """Alt path: no model execution logs in DB → endpoint returns empty list."""
+    response = client.get("/api/logs/model-executions")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_get_model_execution_logs_returns_recorded_entries(client, db):
+    """Happy path: model execution log seeded in DB → returned with numeric metrics."""
+    db.add(ModelExecutionLog(
+        status="success",
+        skus_trained=35,
+        avg_mae=2.5,
+        avg_rmse=3.1,
+        avg_mape=15.0,
+        avg_coverage_ic=0.85,
+        duration_seconds=120.5,
+    ))
+    db.commit()
+
+    response = client.get("/api/logs/model-executions")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["status"] == "success"
+    assert data[0]["skus_trained"] == 35
+    assert float(data[0]["avg_mape"]) == pytest.approx(15.0, rel=0.01)

--- a/frontend/src/__tests__/DemandAlertsTable.test.tsx
+++ b/frontend/src/__tests__/DemandAlertsTable.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Component tests for DemandAlertsTable.
+ *
+ * Covers US-17 — Demand Prediction Alerts:
+ *   - empty state message when no demand alerts exist
+ *   - critical alert renders "Crítico" badge and item_id
+ *   - warning alert renders "Atención" badge
+ *
+ * API calls are mocked so tests are self-contained.
+ */
+
+import { render, screen, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { DemandAlertsTable } from "@/components/demand-alerts-table"
+import { getDemandAlerts } from "@/lib/api"
+import type { DemandAlert } from "@/lib/api"
+
+jest.mock("@/lib/api", () => ({
+  getDemandAlerts: jest.fn(),
+}))
+
+const mockedGetDemandAlerts = getDemandAlerts as jest.MockedFunction<
+  typeof getDemandAlerts
+>
+
+// ---------------------------------------------------------------------------
+// Test data factory
+// ---------------------------------------------------------------------------
+
+function makeDemandAlert(overrides: Partial<DemandAlert> = {}): DemandAlert {
+  return {
+    item_id: "FOODS_001",
+    historical_avg: 2.0,
+    forecast_avg: 3.0,
+    deviation_pct: 50.0,
+    direction: "surge",
+    severity: "critical",
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe("DemandAlertsTable — demand deviation alerts (US-17)", () => {
+  it("shows empty state when API returns no alerts", async () => {
+    mockedGetDemandAlerts.mockResolvedValueOnce({
+      alerts: [],
+      message: "",
+    })
+
+    render(<DemandAlertsTable />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Sin alertas/i)).toBeInTheDocument()
+    })
+  })
+
+  it("renders 'Crítico' badge and item_id for a critical alert", async () => {
+    mockedGetDemandAlerts.mockResolvedValueOnce({
+      alerts: [makeDemandAlert({ item_id: "FOODS_001", severity: "critical" })],
+      message: "Alertas calculadas.",
+    })
+
+    render(<DemandAlertsTable />)
+
+    await waitFor(() => {
+      expect(screen.getByText("Crítico")).toBeInTheDocument()
+      expect(screen.getByText("FOODS_001")).toBeInTheDocument()
+    })
+  })
+
+  it("renders 'Atención' badge for a warning-severity alert", async () => {
+    mockedGetDemandAlerts.mockResolvedValueOnce({
+      alerts: [makeDemandAlert({ severity: "warning", deviation_pct: 30.0 })],
+      message: "",
+    })
+
+    render(<DemandAlertsTable />)
+
+    await waitFor(() => {
+      expect(screen.getByText("Atención")).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/__tests__/ExportUtils.test.ts
+++ b/frontend/src/__tests__/ExportUtils.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Unit tests for the exportToCSV utility.
+ *
+ * Covers US-19 — Report Export:
+ *   - empty data → returns early without touching the DOM or creating a blob
+ *   - data with column mapping → triggers download with the correct filename
+ *     and headers derived from the mapping
+ */
+
+import { exportToCSV } from "@/lib/export"
+
+const mockCreateObjectURL = jest.fn(() => "blob:test-url")
+const mockRevokeObjectURL = jest.fn()
+
+beforeAll(() => {
+  global.URL.createObjectURL = mockCreateObjectURL
+  global.URL.revokeObjectURL = mockRevokeObjectURL
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe("exportToCSV — CSV export utility (US-19)", () => {
+  it("returns early without creating a blob when data array is empty", () => {
+    exportToCSV([], "output.csv")
+
+    expect(mockCreateObjectURL).not.toHaveBeenCalled()
+  })
+
+  it("triggers download with the correct filename when data is provided", () => {
+    const data = [
+      { item_id: "SKU-001", units_sold: 10, sell_price: 5.0 },
+      { item_id: "SKU-002", units_sold: 20, sell_price: 3.5 },
+    ]
+    const appendSpy = jest.spyOn(document.body, "appendChild")
+    const removeSpy = jest.spyOn(document.body, "removeChild")
+
+    exportToCSV(data, "ventas.csv", {
+      item_id: "SKU",
+      units_sold: "Unidades",
+      sell_price: "Precio",
+    })
+
+    expect(mockCreateObjectURL).toHaveBeenCalledTimes(1)
+    expect(appendSpy).toHaveBeenCalledTimes(1)
+    const anchor = appendSpy.mock.calls[0][0] as HTMLAnchorElement
+    expect(anchor.getAttribute("download")).toBe("ventas.csv")
+    expect(removeSpy).toHaveBeenCalledTimes(1)
+
+    appendSpy.mockRestore()
+    removeSpy.mockRestore()
+  })
+})

--- a/frontend/src/__tests__/InventoryProjectionGrid.test.tsx
+++ b/frontend/src/__tests__/InventoryProjectionGrid.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * Component tests for InventoryProjectionGrid.
+ *
+ * Covers US-18 — Future Inventory Projection:
+ *   - shows loading indicator while forecasts are being fetched
+ *   - renders an item card for each provided inventory item
+ *   - items with an active stockout alert show the "Alerta" badge
+ *   - items without alerts show the "OK" badge
+ *
+ * StockProjectionChart is mocked to avoid recharts rendering issues in jsdom.
+ */
+
+import { render, screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { InventoryProjectionGrid } from "@/components/charts/InventoryProjectionGrid"
+import type { InventoryItem, StockoutAlert } from "@/lib/api"
+
+jest.mock("@/components/charts/StockProjectionChart", () => ({
+  StockProjectionChart: () => <div data-testid="stock-projection-chart" />,
+}))
+
+// ---------------------------------------------------------------------------
+// Test data factories
+// ---------------------------------------------------------------------------
+
+function makeItem(overrides: Partial<InventoryItem> = {}): InventoryItem {
+  return {
+    item_id: "SKU-001",
+    store_id: "S1",
+    current_stock: 100,
+    available_stock: 100,
+    lead_time_days: 7,
+    unit_cost: 10.0,
+    next_month_forecast: 300,
+    stock_status: "ok",
+    last_updated: "2024-01-01",
+    reorder_point: null,
+    slow_moving_flag: null,
+    immobilized_capital: null,
+    days_of_stock: null,
+    ...overrides,
+  }
+}
+
+function makeAlert(item_id: string): StockoutAlert {
+  return {
+    item_id,
+    store_id: "S1",
+    current_stock: 5,
+    lead_time_days: 10,
+    avg_daily_demand: 10.0,
+    demand_during_lead_time: 100.0,
+    days_of_stock: 0.5,
+    stockout_date: "2024-02-01",
+    stock_status: "critical",
+    units_to_order: 120,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("InventoryProjectionGrid — stock projection (US-18)", () => {
+  it("shows loading indicator when predsLoading is true", () => {
+    render(
+      <InventoryProjectionGrid
+        items={[makeItem()]}
+        alerts={[]}
+        allPredictions={[]}
+        predsLoading={true}
+      />
+    )
+
+    expect(screen.getByText("Cargando forecast...")).toBeInTheDocument()
+  })
+
+  it("renders a card for each item when not loading", () => {
+    const items = [
+      makeItem({ item_id: "SKU-001" }),
+      makeItem({ item_id: "SKU-002" }),
+    ]
+
+    render(
+      <InventoryProjectionGrid
+        items={items}
+        alerts={[]}
+        allPredictions={[]}
+        predsLoading={false}
+      />
+    )
+
+    expect(screen.getByText("SKU-001")).toBeInTheDocument()
+    expect(screen.getByText("SKU-002")).toBeInTheDocument()
+  })
+
+  it("shows 'Alerta' badge for items with an active stockout alert", () => {
+    const item = makeItem({ item_id: "CRIT-001" })
+    const alert = makeAlert("CRIT-001")
+
+    render(
+      <InventoryProjectionGrid
+        items={[item]}
+        alerts={[alert]}
+        allPredictions={[]}
+        predsLoading={false}
+      />
+    )
+
+    expect(screen.getByText("Alerta")).toBeInTheDocument()
+  })
+
+  it("shows 'OK' badge for items with no active alert", () => {
+    const item = makeItem({ item_id: "OK-001", stock_status: "ok" })
+
+    render(
+      <InventoryProjectionGrid
+        items={[item]}
+        alerts={[]}
+        allPredictions={[]}
+        predsLoading={false}
+      />
+    )
+
+    expect(screen.getByText("OK")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/__tests__/LogsPage.test.tsx
+++ b/frontend/src/__tests__/LogsPage.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Component tests for LogsPage.
+ *
+ * Covers US-20 — Audit Logs:
+ *   - upload log filename renders when the API returns entries
+ *   - empty state message renders when no upload logs exist
+ *
+ * The default api export is mocked so no real HTTP calls are made.
+ */
+
+import React from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom"
+
+jest.mock("@/lib/api", () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+  },
+}))
+
+jest.mock("@/components/dashboard-layout", () => ({
+  DashboardLayout: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+import api from "@/lib/api"
+const mockGet = api.get as jest.Mock
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("LogsPage — audit logs (US-20)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("shows upload log filename when API returns upload log entries", async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === "/api/logs/uploads") {
+        return Promise.resolve({
+          data: [
+            {
+              id: 1,
+              filename: "sales_q1.csv",
+              file_type: "sales",
+              upload_date: "2024-01-15T10:00:00",
+              status: "success",
+              records_processed: 120,
+              error_message: null,
+            },
+          ],
+        })
+      }
+      return Promise.resolve({ data: [] })
+    })
+
+    const LogsPage = (await import("@/app/logs/page")).default
+    render(<LogsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText("sales_q1.csv")).toBeInTheDocument()
+    })
+  })
+
+  it("shows empty state message when no upload logs exist", async () => {
+    mockGet.mockResolvedValue({ data: [] })
+
+    const LogsPage = (await import("@/app/logs/page")).default
+    render(<LogsPage />)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("No hay registros de cargas todavía.")
+      ).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/__tests__/SalesPage.test.tsx
+++ b/frontend/src/__tests__/SalesPage.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Component tests for VentasHistoricasPage.
+ *
+ * Covers US-15 — Sales View:
+ *   - KPI card "Unidades Vendidas" reflects the total from the API response
+ *   - "Sin datos" renders in the top-SKU card when the API returns no records
+ *
+ * API calls and heavy dependencies are mocked.
+ */
+
+import React from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { getSales, getSalesRange } from "@/lib/api"
+
+jest.mock("@/lib/api", () => ({
+  getSales: jest.fn(),
+  getSalesRange: jest.fn(),
+}))
+
+jest.mock("@/components/dashboard-layout", () => ({
+  DashboardLayout: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+jest.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  BarChart: ({ children }: { children: React.ReactNode }) => <svg>{children}</svg>,
+  Bar: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  Cell: () => null,
+}))
+
+const mockGetSales = getSales as jest.MockedFunction<typeof getSales>
+const mockGetSalesRange = getSalesRange as jest.MockedFunction<typeof getSalesRange>
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("VentasHistoricasPage — historical sales view (US-15)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetSalesRange.mockResolvedValue({
+      min_date: "2017-01-01",
+      max_date: "2017-06-30",
+    })
+  })
+
+  it("displays total units sold matching the sum returned by the API", async () => {
+    mockGetSales.mockResolvedValue([
+      {
+        item_id: "FOODS_001",
+        store_id: "S1",
+        cat_id: "FOODS",
+        dept_id: null,
+        date: "2017-06-01",
+        units_sold: 10,
+        sell_price: 5.0,
+      },
+      {
+        item_id: "FOODS_001",
+        store_id: "S1",
+        cat_id: "FOODS",
+        dept_id: null,
+        date: "2017-06-02",
+        units_sold: 15,
+        sell_price: 5.0,
+      },
+    ])
+
+    const VentasPage = (await import("@/app/ventas-historicas/page")).default
+    render(<VentasPage />)
+
+    await waitFor(() => {
+      // KPI card label
+      expect(screen.getByText("Unidades Vendidas")).toBeInTheDocument()
+      // 10 + 15 = 25 formatted with es-CO locale
+      expect(screen.getByText("25")).toBeInTheDocument()
+    })
+  })
+
+  it("shows 'Sin datos' in the top-SKU card when the API returns no sales", async () => {
+    mockGetSales.mockResolvedValue([])
+
+    const VentasPage = (await import("@/app/ventas-historicas/page")).default
+    render(<VentasPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText("Sin datos")).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
## What changed
Adds automated test coverage for all Sprint 3 user stories, following the same patterns established in Sprint 2.

Backend (backend/tests/):
- conftest.py — added UploadLog and ModelExecutionLog to _truncate_all to guarantee isolation between tests
- test_api_endpoints.py — 12 new tests covering GET /api/sales, GET /api/sales/range, GET /api/demand-alerts, GET /api/logs/uploads, and GET /api/logs/model-executions

Frontend (frontend/src/__tests__/):
- SalesPage.test.tsx — US-15: total units sold KPI and empty-data state
- DemandAlertsTable.test.tsx — US-17: critical alert, warning alert, empty state
- InventoryProjectionGrid.test.tsx — US-18: loading state, item cards per SKU, Alerta/OK badges
- ExportUtils.test.ts — US-19: empty data returns early without creating a blob, download triggered with correct filename
- LogsPage.test.tsx — US-20: renders upload log filename, empty state message

## Result
22/22 backend · 24/24 frontend — all tests pass locally and will be picked up automatically by the existing CI pipeline.

## Related issue
Closes US-15, US-17, US-18, US-19, US-20